### PR TITLE
Fix .env file loading when using absolute paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,16 @@ vim ~/Library/Application\ Support/Claude/claude_desktop_config.json
 
 Replace `/ABSOLUTE/PATH/TO/YOUR/PROJECT/kicad-mcp` with the actual path to your project directory.
 
+#### Claude Code (CLI)
+
+For Claude Code users on Linux, macOS, or Windows:
+
+```bash
+claude mcp add kicad /ABSOLUTE/PATH/TO/kicad-mcp/.venv/bin/python -- /ABSOLUTE/PATH/TO/kicad-mcp/main.py
+```
+
+Replace `/ABSOLUTE/PATH/TO/kicad-mcp` with your actual path.
+
 ### 5. Restart Your MCP Client
 
 Close and reopen your MCP client to load the new configuration.

--- a/kicad_mcp/utils/env.py
+++ b/kicad_mcp/utils/env.py
@@ -7,18 +7,24 @@ from typing import Dict, Optional
 
 def load_dotenv(env_file: str = ".env") -> Dict[str, str]:
     """Load environment variables from .env file.
-    
+
     Args:
-        env_file: Path to the .env file
-        
+        env_file: Path to the .env file (can be absolute or relative)
+
     Returns:
         Dictionary of loaded environment variables
     """
     env_vars = {}
     logging.info(f"load_dotenv called for file: {env_file}")
-    
-    # Try to find .env file in the current directory or parent directories
-    env_path = find_env_file(env_file)
+
+    # Check if env_file is an absolute path
+    if os.path.isabs(env_file):
+        env_path = env_file if os.path.exists(env_file) else None
+        if env_path:
+            logging.info(f"Using absolute path: {env_path}")
+    else:
+        # Try to find .env file in the current directory or parent directories
+        env_path = find_env_file(env_file)
     
     if not env_path:
         logging.warning(f"No .env file found matching: {env_file}")

--- a/main.py
+++ b/main.py
@@ -35,7 +35,7 @@ _PID = os.getpid()
 # This attempts to update os.environ
 dotenv_path = os.path.join(os.path.dirname(__file__), '.env')
 logging.info(f"Attempting to load .env file from: {dotenv_path}")
-found_dotenv = load_dotenv() # Assuming this returns True/False or similar
+found_dotenv = load_dotenv(dotenv_path) # Assuming this returns True/False or similar
 logging.info(f".env file found and loaded: {found_dotenv}")
 
 # Log effective values AFTER load_dotenv attempt


### PR DESCRIPTION
## Summary
- Fix `load_dotenv()` to properly use the absolute path passed from `main.py`
- Add support for absolute paths in `load_dotenv()` to skip unnecessary directory search
- Add Claude Code CLI setup instructions to README

## Problem
The `.env` file was not being loaded because `main.py` calculated the correct absolute path but `load_dotenv()` was called without passing it, causing it to search from the current working directory instead.

## Test plan
- [x] Verify `.env` file is loaded when MCP server starts (check `kicad-mcp.log`)
- [x] Verify `list_projects` tool finds projects in configured `KICAD_SEARCH_PATHS`
- [x] Test on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)