### PR TITLE
Add .local/ directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ fp-info-cache
 *.kicad_sch.lck
 *.kicad_pcb.lck
 *.kicad_pro.lck
+
+# Local development notes
+.local/


### PR DESCRIPTION
Adds `.local/` to gitignore for developer-specific scratch files (notes, test scripts, temporary files).

Provides an IDE-agnostic standard location that won't conflict with existing Python/KiCad tooling.

Generated with [Claude Code](https://claude.com/claude-code)