### PR TITLE
Add footprint library tools with caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ fp-info-cache
 *.kicad_sch.lck
 *.kicad_pcb.lck
 *.kicad_pro.lck
+
+# Local development notes
+.local/

--- a/.local/FOOTPRINT_TOOLS_TEST_PLAN.md
+++ b/.local/FOOTPRINT_TOOLS_TEST_PLAN.md
@@ -1,0 +1,37 @@
+# Footprint Tools Test Plan
+
+## 1. List Libraries
+`mcp__kicad__list_footprint_libraries`
+- Returns 150+ libraries, sorted, without `.pretty` extension
+
+## 2. Rebuild Index
+`mcp__kicad__rebuild_footprint_index`
+- Creates cache at `~/.cache/kicad-mcp/footprint_index.json`
+- Returns 15000+ footprints, 150+ libraries
+- Progress 0-100%, takes 30-90s
+
+## 3. Search
+`mcp__kicad__search_footprints`
+- Query `"0805"` → resistors and capacitors
+- Query `"SOIC-8"` → Package_SO results
+- With library filter → only that library
+- With limit=5 → truncated results
+- Nonexistent query → 0 matches
+
+## 4. Validate
+`mcp__kicad__validate_footprint_exists`
+- `Resistor_SMD:R_0805_2012Metric` → exists=true with description
+- `InvalidFormat` → exists=false, format error
+- `NonExistent:R_0805` → exists=false, suggestions
+- `Resistor_SMD:R_9999` → exists=false, similar footprints
+
+## 5. Get Pads
+`mcp__kicad__get_footprint_pads`
+- `Resistor_SMD:R_0805_2012Metric` → 2 SMD pads, no drill
+- `Package_DIP:DIP-8_W7.62mm` → 8 thru_hole pads with drill
+- Invalid footprint → error with suggestions
+
+## Edge Cases
+- Search without cache → "missing" status, rebuild prompt
+- Search with stale cache → "stale" status, rebuild prompt
+- Rebuild over existing cache → updates timestamp

--- a/README.md
+++ b/README.md
@@ -102,6 +102,16 @@ vim ~/Library/Application\ Support/Claude/claude_desktop_config.json
 
 Replace `/ABSOLUTE/PATH/TO/YOUR/PROJECT/kicad-mcp` with the actual path to your project directory.
 
+#### Claude Code (CLI)
+
+For Claude Code users on Linux, macOS, or Windows:
+
+```bash
+claude mcp add kicad /ABSOLUTE/PATH/TO/kicad-mcp/.venv/bin/python -- /ABSOLUTE/PATH/TO/kicad-mcp/main.py
+```
+
+Replace `/ABSOLUTE/PATH/TO/kicad-mcp` with your actual path.
+
 ### 5. Restart Your MCP Client
 
 Close and reopen your MCP client to load the new configuration.

--- a/kicad_mcp/server.py
+++ b/kicad_mcp/server.py
@@ -26,6 +26,7 @@ from kicad_mcp.tools.drc_tools import register_drc_tools
 from kicad_mcp.tools.bom_tools import register_bom_tools
 from kicad_mcp.tools.netlist_tools import register_netlist_tools
 from kicad_mcp.tools.pattern_tools import register_pattern_tools
+from kicad_mcp.tools.symbol_tools import register_symbol_tools
 
 # Import prompt handlers
 from kicad_mcp.prompts.templates import register_prompts
@@ -153,7 +154,8 @@ def create_server() -> FastMCP:
     register_bom_tools(mcp)
     register_netlist_tools(mcp)
     register_pattern_tools(mcp)
-    
+    register_symbol_tools(mcp)
+
     # Register prompts
     logging.info(f"Registering prompts...")
     register_prompts(mcp)

--- a/kicad_mcp/server.py
+++ b/kicad_mcp/server.py
@@ -27,6 +27,7 @@ from kicad_mcp.tools.bom_tools import register_bom_tools
 from kicad_mcp.tools.netlist_tools import register_netlist_tools
 from kicad_mcp.tools.pattern_tools import register_pattern_tools
 from kicad_mcp.tools.symbol_tools import register_symbol_tools
+from kicad_mcp.tools.footprint_tools import register_footprint_tools
 
 # Import prompt handlers
 from kicad_mcp.prompts.templates import register_prompts
@@ -155,6 +156,7 @@ def create_server() -> FastMCP:
     register_netlist_tools(mcp)
     register_pattern_tools(mcp)
     register_symbol_tools(mcp)
+    register_footprint_tools(mcp)
 
     # Register prompts
     logging.info(f"Registering prompts...")

--- a/kicad_mcp/tools/__init__.py
+++ b/kicad_mcp/tools/__init__.py
@@ -6,4 +6,5 @@ This package includes:
 - Analysis tools
 - Export tools (BOM extraction, PCB thumbnail generation)
 - DRC tools
+- Symbol library tools
 """

--- a/kicad_mcp/tools/footprint_tools.py
+++ b/kicad_mcp/tools/footprint_tools.py
@@ -1,0 +1,432 @@
+"""
+Footprint library tools for KiCad.
+
+Provides tools for querying footprint libraries, validating footprints,
+and retrieving pad information.
+"""
+
+from difflib import SequenceMatcher
+import os
+import re
+from typing import Any
+
+from mcp.server.fastmcp import Context, FastMCP
+
+from kicad_mcp.config import KICAD_APP_PATH, system
+from kicad_mcp.utils.footprint_cache import (
+    get_cache_path,
+    get_or_build_index,
+    search_index,
+)
+
+
+def get_footprint_library_path() -> str:
+    """Get the path to KiCad's footprint libraries.
+
+    Returns:
+        Path to the footprint libraries directory
+    """
+    if system == "Darwin":
+        return os.path.join(KICAD_APP_PATH, "Contents/SharedSupport/footprints")
+    elif system == "Windows":
+        return os.path.join(KICAD_APP_PATH, "share", "kicad", "footprints")
+    else:  # Linux
+        return "/usr/share/kicad/footprints"
+
+
+def list_available_libraries() -> list[str]:
+    """List all available footprint library names.
+
+    Returns:
+        Sorted list of library names (without .pretty extension)
+    """
+    lib_path = get_footprint_library_path()
+    if not os.path.exists(lib_path):
+        return []
+
+    libraries = []
+    for d in os.listdir(lib_path):
+        if d.endswith(".pretty") and os.path.isdir(os.path.join(lib_path, d)):
+            libraries.append(d[:-7])  # Remove .pretty extension
+    return sorted(libraries)
+
+
+def parse_footprint_identifier(footprint_id: str) -> tuple[str, str]:
+    """Parse library:footprint format into (library, footprint) tuple.
+
+    Args:
+        footprint_id: Footprint identifier in format 'Library:FootprintName'
+
+    Returns:
+        Tuple of (library_name, footprint_name)
+
+    Raises:
+        ValueError: If footprint_id is not in correct format
+    """
+    if ":" not in footprint_id:
+        raise ValueError(
+            f"Invalid footprint identifier '{footprint_id}'. Expected format: 'Library:FootprintName'"
+        )
+    parts = footprint_id.split(":", 1)
+    return parts[0], parts[1]
+
+
+def read_footprint_file(library_name: str, footprint_name: str) -> str | None:
+    """Read a footprint file content.
+
+    Args:
+        library_name: Name of the library (without .pretty extension)
+        footprint_name: Name of the footprint (without .kicad_mod extension)
+
+    Returns:
+        Footprint file content as string, or None if not found
+    """
+    lib_path = get_footprint_library_path()
+    file_path = os.path.join(lib_path, f"{library_name}.pretty", f"{footprint_name}.kicad_mod")
+
+    if not os.path.exists(file_path):
+        return None
+
+    with open(file_path, encoding="utf-8") as f:
+        return f.read()
+
+
+# Pre-compiled patterns for footprint parsing
+_PAD_PATTERN = re.compile(
+    r'\(pad\s+"?([^"\s]+)"?\s+(\w+)\s+(\w+)'  # number, type, shape
+    r".*?\(at\s+([\d.-]+)\s+([\d.-]+)(?:\s+([\d.-]+))?\)",  # at X Y [angle]
+    re.DOTALL,
+)
+_PAD_SIZE_PATTERN = re.compile(r"\(size\s+([\d.-]+)\s+([\d.-]+)\)")
+_PAD_DRILL_PATTERN = re.compile(r"\(drill\s+([\d.-]+)(?:\s+([\d.-]+))?\)")
+_DESC_PATTERN = re.compile(r'\(descr\s+"([^"]*)"')
+_TAGS_PATTERN = re.compile(r'\(tags\s+"([^"]*)"')
+_FP_NAME_PATTERN = re.compile(r'\(footprint\s+"([^"]+)"')
+
+
+def parse_pads_from_footprint(footprint_content: str) -> list[dict[str, Any]]:
+    """Parse pad information from footprint S-expression content.
+
+    Args:
+        footprint_content: S-expression content of the footprint
+
+    Returns:
+        List of pad dictionaries with number, type, shape, position, size, etc.
+    """
+    pads = []
+
+    for match in _PAD_PATTERN.finditer(footprint_content):
+        pad_num, pad_type, pad_shape, x, y, angle = match.groups()
+
+        # Get the pad block for additional info
+        pad_start = match.start()
+        depth = 0
+        pad_end = pad_start
+        for i, char in enumerate(footprint_content[pad_start:], pad_start):
+            if char == "(":
+                depth += 1
+            elif char == ")":
+                depth -= 1
+                if depth == 0:
+                    pad_end = i + 1
+                    break
+
+        pad_block = footprint_content[pad_start:pad_end]
+
+        # Extract size
+        size_match = _PAD_SIZE_PATTERN.search(pad_block)
+        size = [float(size_match.group(1)), float(size_match.group(2))] if size_match else [0, 0]
+
+        # Extract drill (for through-hole pads)
+        drill_match = _PAD_DRILL_PATTERN.search(pad_block)
+        drill = None
+        if drill_match:
+            drill_x = float(drill_match.group(1))
+            drill_y = float(drill_match.group(2)) if drill_match.group(2) else drill_x
+            drill = [drill_x, drill_y]
+
+        pads.append(
+            {
+                "number": pad_num,
+                "type": pad_type,  # smd, thru_hole, np_thru_hole, connect
+                "shape": pad_shape,  # circle, rect, oval, roundrect, trapezoid, custom
+                "position": [float(x), float(y)],
+                "angle": float(angle) if angle else 0.0,
+                "size": size,
+                "drill": drill,
+            }
+        )
+
+    return pads
+
+
+def get_all_footprints_in_library(library_path: str) -> list[dict[str, str]]:
+    """Extract all footprint names and descriptions from a library directory.
+
+    Args:
+        library_path: Full path to the .pretty directory
+
+    Returns:
+        List of dictionaries with name, description, and keywords
+    """
+    footprints = []
+
+    if not os.path.exists(library_path):
+        return []
+
+    for filename in os.listdir(library_path):
+        if not filename.endswith(".kicad_mod"):
+            continue
+
+        footprint_name = filename[:-10]  # Remove .kicad_mod
+        filepath = os.path.join(library_path, filename)
+
+        try:
+            with open(filepath, encoding="utf-8") as f:
+                content = f.read()
+
+            description = ""
+            keywords = ""
+
+            desc_match = _DESC_PATTERN.search(content)
+            if desc_match:
+                description = desc_match.group(1)
+
+            tags_match = _TAGS_PATTERN.search(content)
+            if tags_match:
+                keywords = tags_match.group(1)
+
+            footprints.append(
+                {
+                    "name": footprint_name,
+                    "description": description,
+                    "keywords": keywords,
+                }
+            )
+        except Exception:
+            # Skip unreadable files
+            continue
+
+    return footprints
+
+
+def find_similar_footprints(target: str, all_footprints: list[str], limit: int = 5) -> list[str]:
+    """Find footprints similar to the target name.
+
+    Args:
+        target: Footprint name to find similar matches for
+        all_footprints: List of all available footprint names
+        limit: Maximum number of suggestions to return
+
+    Returns:
+        List of similar footprint names, sorted by similarity
+    """
+    scored = []
+    target_lower = target.lower()
+
+    for fp in all_footprints:
+        fp_lower = fp.lower()
+        # Exact substring match gets high score
+        if target_lower in fp_lower:
+            score = 0.8 + (len(target) / len(fp)) * 0.2
+        else:
+            score = SequenceMatcher(None, target_lower, fp_lower).ratio()
+        scored.append((fp, score))
+
+    scored.sort(key=lambda x: x[1], reverse=True)
+    return [s[0] for s in scored[:limit]]
+
+
+def register_footprint_tools(mcp: FastMCP) -> None:
+    """Register footprint library tools with the MCP server.
+
+    Args:
+        mcp: The FastMCP server instance
+    """
+
+    @mcp.tool()
+    def get_footprint_pads(footprint_id: str) -> dict[str, Any]:
+        """Get pad information for a KiCad footprint.
+
+        Args:
+            footprint_id: Footprint identifier in format 'Library:FootprintName'
+                         (e.g., 'Resistor_SMD:R_0805_2012Metric', 'Package_SO:SOIC-8_3.9x4.9mm_P1.27mm')
+
+        Returns:
+            Dictionary with pad information including numbers, types, positions, sizes
+        """
+        print(f"Getting pads for footprint: {footprint_id}")
+
+        try:
+            library, footprint_name = parse_footprint_identifier(footprint_id)
+        except ValueError as e:
+            print(f"Invalid footprint identifier: {footprint_id}")
+            return {"success": False, "error": str(e)}
+
+        footprint_content = read_footprint_file(library, footprint_name)
+        if footprint_content is None:
+            print(f"Footprint not found: {footprint_id}")
+            available = list_available_libraries()
+            similar = find_similar_footprints(library, available)
+            return {
+                "success": False,
+                "error": f"Footprint '{footprint_name}' not found in library '{library}'",
+                "suggestions": similar,
+            }
+
+        pads = parse_pads_from_footprint(footprint_content)
+        print(f"Found {len(pads)} pads for {footprint_id}")
+
+        return {
+            "success": True,
+            "footprint": footprint_id,
+            "pad_count": len(pads),
+            "pads": pads,
+        }
+
+    @mcp.tool()
+    def validate_footprint_exists(footprint_id: str) -> dict[str, Any]:
+        """Check if a KiCad footprint exists and suggest alternatives if not.
+
+        Args:
+            footprint_id: Footprint identifier in format 'Library:FootprintName'
+
+        Returns:
+            Dictionary with exists status and suggestions if not found
+        """
+        print(f"Validating footprint: {footprint_id}")
+
+        try:
+            library, footprint_name = parse_footprint_identifier(footprint_id)
+        except ValueError as e:
+            return {"exists": False, "error": str(e), "suggestions": []}
+
+        footprint_content = read_footprint_file(library, footprint_name)
+        if footprint_content is None:
+            print(f"Footprint not found: {footprint_id}")
+            lib_path = get_footprint_library_path()
+            pretty_path = os.path.join(lib_path, f"{library}.pretty")
+
+            if not os.path.exists(pretty_path):
+                # Library doesn't exist
+                available = list_available_libraries()
+                similar = find_similar_footprints(library, available)
+                return {
+                    "exists": False,
+                    "error": f"Library '{library}' not found",
+                    "suggestions": [f"{lib}:{footprint_name}" for lib in similar[:3]],
+                }
+
+            # Library exists but footprint doesn't
+            all_fps = get_all_footprints_in_library(pretty_path)
+            fp_names = [fp["name"] for fp in all_fps]
+            similar = find_similar_footprints(footprint_name, fp_names)
+            return {
+                "exists": False,
+                "error": f"Footprint '{footprint_name}' not found in library '{library}'",
+                "suggestions": [f"{library}:{fp}" for fp in similar],
+            }
+
+        # Extract additional info for valid footprint
+        desc_match = _DESC_PATTERN.search(footprint_content)
+        tags_match = _TAGS_PATTERN.search(footprint_content)
+
+        print(f"Footprint exists: {footprint_id}")
+        return {
+            "exists": True,
+            "footprint": footprint_id,
+            "description": desc_match.group(1) if desc_match else "",
+            "keywords": tags_match.group(1) if tags_match else "",
+        }
+
+    @mcp.tool()
+    def search_footprints(
+        query: str, library: str | None = None, limit: int = 20
+    ) -> dict[str, Any]:
+        """Search for KiCad footprints by keyword.
+
+        Args:
+            query: Search keyword (e.g., 'SOIC', '0805', 'QFP')
+            library: Optional library name to search within (searches all if not specified)
+            limit: Maximum number of results to return (default 20)
+
+        Returns:
+            List of matching footprints with their library:footprint identifiers
+        """
+        from kicad_mcp.utils.footprint_cache import is_cache_valid, load_footprint_index
+
+        print(f"Searching footprints for: {query}")
+
+        library_path = get_footprint_library_path()
+        cached = load_footprint_index()
+
+        # Check if cache exists and is valid
+        if not cached:
+            return {
+                "success": False,
+                "cache_status": "missing",
+                "message": "Footprint index not built yet. Run rebuild_footprint_index first.",
+            }
+
+        if not is_cache_valid(cached, library_path):
+            return {
+                "success": False,
+                "cache_status": "stale",
+                "message": "Footprint libraries have changed. Run rebuild_footprint_index to update.",
+            }
+
+        # Search the index
+        search_result = search_index(cached, query, library, limit)
+
+        print(f"Found {search_result['total_matches']} matching footprints")
+        return {
+            "success": True,
+            "cache_status": "valid",
+            "query": query,
+            "total_matches": search_result["total_matches"],
+            "result_count": len(search_result["results"]),
+            "truncated": search_result["truncated"],
+            "results": search_result["results"],
+        }
+
+    @mcp.tool()
+    async def rebuild_footprint_index(ctx: Context | None = None) -> dict[str, Any]:
+        """Rebuild the footprint index cache.
+
+        Force a rebuild of the cached footprint index. Use this when:
+        - KiCad libraries have been updated
+        - New footprint libraries have been installed
+        - Footprint index appears corrupted or stale
+
+        Returns:
+            Dictionary with rebuild results
+        """
+        print("Rebuilding footprint index...")
+
+        library_path = get_footprint_library_path()
+        index_data = await get_or_build_index(library_path, force_rebuild=True, ctx=ctx)
+
+        return {
+            "success": True,
+            "message": "Footprint index rebuilt successfully",
+            "footprint_count": index_data["footprint_count"],
+            "library_count": index_data["library_count"],
+            "cache_path": get_cache_path(),
+            "timestamp": index_data["timestamp"],
+        }
+
+    @mcp.tool()
+    def list_footprint_libraries() -> dict[str, Any]:
+        """List all available KiCad footprint libraries.
+
+        Returns:
+            List of library names that can be used with other footprint tools
+        """
+        print("Listing footprint libraries")
+        libraries = list_available_libraries()
+        return {
+            "success": True,
+            "library_count": len(libraries),
+            "libraries": libraries,
+            "library_path": get_footprint_library_path(),
+        }

--- a/kicad_mcp/tools/symbol_tools.py
+++ b/kicad_mcp/tools/symbol_tools.py
@@ -1,0 +1,468 @@
+"""
+Symbol library tools for KiCad.
+
+Provides tools for querying symbol libraries, validating symbols,
+and retrieving pin information.
+"""
+
+from difflib import SequenceMatcher
+import os
+import re
+from typing import Any
+
+from mcp.server.fastmcp import Context, FastMCP
+
+from kicad_mcp.config import KICAD_APP_PATH, system
+from kicad_mcp.utils.symbol_cache import (
+    get_cache_path,
+    get_or_build_index,
+    search_index,
+)
+
+
+def get_symbol_library_path() -> str:
+    """Get the path to KiCad's symbol libraries.
+
+    Returns:
+        Path to the symbol libraries directory
+    """
+    if system == "Darwin":
+        return os.path.join(KICAD_APP_PATH, "Contents/SharedSupport/symbols")
+    elif system == "Windows":
+        return os.path.join(KICAD_APP_PATH, "share", "kicad", "symbols")
+    else:  # Linux
+        return "/usr/share/kicad/symbols"
+
+
+def list_available_libraries() -> list[str]:
+    """List all available symbol library names.
+
+    Returns:
+        Sorted list of library names (without .kicad_sym extension)
+    """
+    lib_path = get_symbol_library_path()
+    if not os.path.exists(lib_path):
+        return []
+
+    libraries = []
+    for f in os.listdir(lib_path):
+        if f.endswith(".kicad_sym"):
+            libraries.append(f[:-10])  # Remove .kicad_sym extension
+    return sorted(libraries)
+
+
+def parse_symbol_identifier(symbol_id: str) -> tuple[str, str]:
+    """Parse library:symbol format into (library, symbol) tuple.
+
+    Args:
+        symbol_id: Symbol identifier in format 'Library:SymbolName'
+
+    Returns:
+        Tuple of (library_name, symbol_name)
+
+    Raises:
+        ValueError: If symbol_id is not in correct format
+    """
+    if ":" not in symbol_id:
+        raise ValueError(
+            f"Invalid symbol identifier '{symbol_id}'. Expected format: 'Library:SymbolName'"
+        )
+    parts = symbol_id.split(":", 1)
+    return parts[0], parts[1]
+
+
+def read_library_file(library_name: str) -> str | None:
+    """Read a symbol library file content.
+
+    Args:
+        library_name: Name of the library (without .kicad_sym extension)
+
+    Returns:
+        Library file content as string, or None if not found
+    """
+    lib_path = get_symbol_library_path()
+    file_path = os.path.join(lib_path, f"{library_name}.kicad_sym")
+
+    if not os.path.exists(file_path):
+        return None
+
+    with open(file_path, encoding="utf-8") as f:
+        return f.read()
+
+
+def extract_symbol_content(library_content: str, symbol_name: str) -> str | None:
+    """Extract a specific symbol's S-expression block from library content.
+
+    Args:
+        library_content: Full content of the library file
+        symbol_name: Name of the symbol to extract
+
+    Returns:
+        Symbol S-expression block, or None if not found
+    """
+    # Match symbol block - handles nested parentheses
+    pattern = rf'\(symbol "{re.escape(symbol_name)}"'
+    match = re.search(pattern, library_content)
+
+    if not match:
+        return None
+
+    start = match.start()
+    depth = 0
+    end = start
+
+    for i, char in enumerate(library_content[start:], start):
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+            if depth == 0:
+                end = i + 1
+                break
+
+    return library_content[start:end]
+
+
+def parse_pins_from_symbol(symbol_content: str, library_content: str) -> list[dict[str, Any]]:
+    """Parse pin information from symbol S-expression content.
+
+    Handles symbol inheritance via 'extends'.
+
+    Args:
+        symbol_content: S-expression content of the symbol
+        library_content: Full library content (for resolving extends)
+
+    Returns:
+        List of pin dictionaries with name, number, position, etc.
+    """
+    pins = []
+
+    # Check for extends clause
+    extends_match = re.search(r'\(extends "([^"]+)"\)', symbol_content)
+    if extends_match:
+        base_symbol = extends_match.group(1)
+        base_content = extract_symbol_content(library_content, base_symbol)
+        if base_content:
+            pins = parse_pins_from_symbol(base_content, library_content)
+
+    # Parse pins from this symbol (may override inherited pins)
+    # Pin format: (pin <type> <shape> (at X Y ANGLE) (length L) (name "NAME" ...) (number "NUM" ...))
+    pin_pattern = re.compile(
+        r"\(pin\s+(\w+)\s+(\w+)\s*"  # type and shape
+        r"\(at\s+([\d.-]+)\s+([\d.-]+)\s+([\d.-]+)\)"  # at X Y ANGLE
+        r"\s*\(length\s+([\d.-]+)\)"  # length
+        r'\s*\(name\s+"([^"]*)"\s*'  # name
+        r'.*?\(number\s+"([^"]+)"',  # number
+        re.DOTALL,
+    )
+
+    for match in pin_pattern.finditer(symbol_content):
+        pin_type, pin_shape, x, y, angle, length, name, number = match.groups()
+        pins.append(
+            {
+                "name": name if name != "~" else "",
+                "number": number,
+                "position": [float(x), float(y)],
+                "angle": float(angle),
+                "length": float(length),
+                "type": pin_type,
+                "shape": pin_shape,
+            }
+        )
+
+    return pins
+
+
+# Pre-compiled patterns for symbol extraction
+_SYMBOL_HEADER_PATTERN = re.compile(r'\n\t\(symbol "([^"]+)"')
+_DESC_PATTERN = re.compile(r'\(property "Description"\s+"([^"]*)"')
+_KEYWORDS_PATTERN = re.compile(r'\(property "ki_keywords"\s+"([^"]*)"')
+
+
+def get_all_symbols_in_library(library_content: str) -> list[dict[str, str]]:
+    """Extract all symbol names and descriptions from a library.
+
+    Uses single-pass parsing for efficiency.
+
+    Args:
+        library_content: Full content of the library file
+
+    Returns:
+        List of dictionaries with name, description, and keywords
+    """
+    symbols = []
+
+    # Find all symbol start positions first
+    symbol_matches = list(_SYMBOL_HEADER_PATTERN.finditer(library_content))
+
+    for i, match in enumerate(symbol_matches):
+        symbol_name = match.group(1)
+
+        # Skip internal symbol units (e.g., Symbol_0_1, Symbol_1_1)
+        if "_" in symbol_name:
+            parts = symbol_name.split("_")
+            if parts[-1].isdigit():
+                continue
+            if len(parts) >= 2 and parts[-2].isdigit():
+                continue
+
+        # Get block boundaries - from this symbol to next (or end)
+        block_start = match.start()
+        if i + 1 < len(symbol_matches):
+            block_end = symbol_matches[i + 1].start()
+        else:
+            block_end = len(library_content)
+
+        block = library_content[block_start:block_end]
+
+        # Extract description and keywords from block
+        description = ""
+        keywords = ""
+
+        desc_match = _DESC_PATTERN.search(block)
+        if desc_match:
+            description = desc_match.group(1)
+
+        kw_match = _KEYWORDS_PATTERN.search(block)
+        if kw_match:
+            keywords = kw_match.group(1)
+
+        symbols.append(
+            {
+                "name": symbol_name,
+                "description": description,
+                "keywords": keywords,
+            }
+        )
+
+    return symbols
+
+
+def find_similar_symbols(target: str, all_symbols: list[str], limit: int = 5) -> list[str]:
+    """Find symbols similar to the target name.
+
+    Args:
+        target: Symbol name to find similar matches for
+        all_symbols: List of all available symbol names
+        limit: Maximum number of suggestions to return
+
+    Returns:
+        List of similar symbol names, sorted by similarity
+    """
+    scored = []
+    target_lower = target.lower()
+
+    for sym in all_symbols:
+        sym_lower = sym.lower()
+        # Exact substring match gets high score
+        if target_lower in sym_lower:
+            score = 0.8 + (len(target) / len(sym)) * 0.2
+        else:
+            score = SequenceMatcher(None, target_lower, sym_lower).ratio()
+        scored.append((sym, score))
+
+    scored.sort(key=lambda x: x[1], reverse=True)
+    return [s[0] for s in scored[:limit]]
+
+
+def register_symbol_tools(mcp: FastMCP) -> None:
+    """Register symbol library tools with the MCP server.
+
+    Args:
+        mcp: The FastMCP server instance
+    """
+
+    @mcp.tool()
+    def get_symbol_pins(symbol_id: str) -> dict[str, Any]:
+        """Get pin information for a KiCad symbol.
+
+        Args:
+            symbol_id: Symbol identifier in format 'Library:SymbolName'
+                       (e.g., 'MCU_Microchip_ATtiny:ATtiny85-20P', 'Device:R')
+
+        Returns:
+            Dictionary with pin information including names, numbers, positions
+        """
+        print(f"Getting pins for symbol: {symbol_id}")
+
+        try:
+            library, symbol_name = parse_symbol_identifier(symbol_id)
+        except ValueError as e:
+            print(f"Invalid symbol identifier: {symbol_id}")
+            return {"success": False, "error": str(e)}
+
+        library_content = read_library_file(library)
+        if library_content is None:
+            print(f"Library not found: {library}")
+            available = list_available_libraries()
+            similar = find_similar_symbols(library, available)
+            return {
+                "success": False,
+                "error": f"Library '{library}' not found",
+                "suggestions": similar,
+            }
+
+        symbol_content = extract_symbol_content(library_content, symbol_name)
+        if symbol_content is None:
+            print(f"Symbol not found: {symbol_name} in library {library}")
+            # Find similar symbols in this library
+            all_syms = get_all_symbols_in_library(library_content)
+            sym_names = [s["name"] for s in all_syms]
+            similar = find_similar_symbols(symbol_name, sym_names)
+            return {
+                "success": False,
+                "error": f"Symbol '{symbol_name}' not found in library '{library}'",
+                "suggestions": [f"{library}:{s}" for s in similar],
+            }
+
+        pins = parse_pins_from_symbol(symbol_content, library_content)
+        print(f"Found {len(pins)} pins for {symbol_id}")
+
+        return {
+            "success": True,
+            "symbol": symbol_id,
+            "pin_count": len(pins),
+            "pins": pins,
+        }
+
+    @mcp.tool()
+    def validate_symbol_exists(symbol_id: str) -> dict[str, Any]:
+        """Check if a KiCad symbol exists and suggest alternatives if not.
+
+        Args:
+            symbol_id: Symbol identifier in format 'Library:SymbolName'
+
+        Returns:
+            Dictionary with exists status and suggestions if not found
+        """
+        print(f"Validating symbol: {symbol_id}")
+
+        try:
+            library, symbol_name = parse_symbol_identifier(symbol_id)
+        except ValueError as e:
+            return {"exists": False, "error": str(e), "suggestions": []}
+
+        library_content = read_library_file(library)
+        if library_content is None:
+            print(f"Library not found: {library}")
+            available = list_available_libraries()
+            similar = find_similar_symbols(library, available)
+            return {
+                "exists": False,
+                "error": f"Library '{library}' not found",
+                "suggestions": [f"{lib}:{symbol_name}" for lib in similar[:3]],
+            }
+
+        symbol_content = extract_symbol_content(library_content, symbol_name)
+        if symbol_content is None:
+            print(f"Symbol not found: {symbol_name}")
+            all_syms = get_all_symbols_in_library(library_content)
+            sym_names = [s["name"] for s in all_syms]
+            similar = find_similar_symbols(symbol_name, sym_names)
+            return {
+                "exists": False,
+                "error": f"Symbol '{symbol_name}' not found in library '{library}'",
+                "suggestions": [f"{library}:{s}" for s in similar],
+            }
+
+        # Extract additional info for valid symbol
+        desc_match = re.search(r'\(property "Description"\s+"([^"]*)"', symbol_content)
+        footprint_match = re.search(r'\(property "Footprint"\s+"([^"]*)"', symbol_content)
+
+        print(f"Symbol exists: {symbol_id}")
+        return {
+            "exists": True,
+            "symbol": symbol_id,
+            "description": desc_match.group(1) if desc_match else "",
+            "default_footprint": footprint_match.group(1) if footprint_match else "",
+        }
+
+    @mcp.tool()
+    def search_symbols(query: str, library: str | None = None, limit: int = 20) -> dict[str, Any]:
+        """Search for KiCad symbols by keyword.
+
+        Args:
+            query: Search keyword (e.g., 'ESP32', 'voltage regulator', 'ATmega')
+            library: Optional library name to search within (searches all if not specified)
+            limit: Maximum number of results to return (default 20)
+
+        Returns:
+            List of matching symbols with their library:symbol identifiers
+        """
+        from kicad_mcp.utils.symbol_cache import is_cache_valid, load_symbol_index
+
+        print(f"Searching symbols for: {query}")
+
+        library_path = get_symbol_library_path()
+        cached = load_symbol_index()
+
+        # Check if cache exists and is valid
+        if not cached:
+            return {
+                "success": False,
+                "cache_status": "missing",
+                "message": "Symbol index not built yet. Run rebuild_symbol_index first (takes ~2-3 min).",
+            }
+
+        if not is_cache_valid(cached, library_path):
+            return {
+                "success": False,
+                "cache_status": "stale",
+                "message": "Symbol libraries have changed. Run rebuild_symbol_index to update (~2-3 min).",
+            }
+
+        # Search the index
+        search_result = search_index(cached, query, library, limit)
+
+        print(f"Found {search_result['total_matches']} matching symbols")
+        return {
+            "success": True,
+            "cache_status": "valid",
+            "query": query,
+            "total_matches": search_result["total_matches"],
+            "result_count": len(search_result["results"]),
+            "truncated": search_result["truncated"],
+            "results": search_result["results"],
+        }
+
+    @mcp.tool()
+    async def rebuild_symbol_index(ctx: Context | None = None) -> dict[str, Any]:
+        """Rebuild the symbol index cache.
+
+        Force a rebuild of the cached symbol index. Use this when:
+        - KiCad libraries have been updated
+        - New symbol libraries have been installed
+        - Symbol index appears corrupted or stale
+
+        Returns:
+            Dictionary with rebuild results
+        """
+        print("Rebuilding symbol index...")
+
+        library_path = get_symbol_library_path()
+        index_data = await get_or_build_index(library_path, force_rebuild=True, ctx=ctx)
+
+        return {
+            "success": True,
+            "message": "Symbol index rebuilt successfully",
+            "symbol_count": index_data["symbol_count"],
+            "library_count": index_data["library_count"],
+            "cache_path": get_cache_path(),
+            "timestamp": index_data["timestamp"],
+        }
+
+    @mcp.tool()
+    def list_symbol_libraries() -> dict[str, Any]:
+        """List all available KiCad symbol libraries.
+
+        Returns:
+            List of library names that can be used with other symbol tools
+        """
+        print("Listing symbol libraries")
+        libraries = list_available_libraries()
+        return {
+            "success": True,
+            "library_count": len(libraries),
+            "libraries": libraries,
+            "library_path": get_symbol_library_path(),
+        }

--- a/kicad_mcp/utils/env.py
+++ b/kicad_mcp/utils/env.py
@@ -7,18 +7,24 @@ from typing import Dict, Optional
 
 def load_dotenv(env_file: str = ".env") -> Dict[str, str]:
     """Load environment variables from .env file.
-    
+
     Args:
-        env_file: Path to the .env file
-        
+        env_file: Path to the .env file (can be absolute or relative)
+
     Returns:
         Dictionary of loaded environment variables
     """
     env_vars = {}
     logging.info(f"load_dotenv called for file: {env_file}")
-    
-    # Try to find .env file in the current directory or parent directories
-    env_path = find_env_file(env_file)
+
+    # Check if env_file is an absolute path
+    if os.path.isabs(env_file):
+        env_path = env_file if os.path.exists(env_file) else None
+        if env_path:
+            logging.info(f"Using absolute path: {env_path}")
+    else:
+        # Try to find .env file in the current directory or parent directories
+        env_path = find_env_file(env_file)
     
     if not env_path:
         logging.warning(f"No .env file found matching: {env_file}")

--- a/kicad_mcp/utils/footprint_cache.py
+++ b/kicad_mcp/utils/footprint_cache.py
@@ -1,0 +1,320 @@
+"""
+Footprint index cache management for fast footprint searches.
+
+Builds and maintains a cached index of all KiCad footprints to avoid
+parsing many library directories on every search.
+"""
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime
+import hashlib
+import json
+import logging
+import os
+from typing import Any
+
+from filelock import FileLock, Timeout
+
+logger = logging.getLogger(__name__)
+
+
+def get_cache_dir() -> str:
+    """Get the cache directory path.
+
+    Returns:
+        Path to cache directory (created if doesn't exist)
+    """
+    if os.name == "nt":  # Windows
+        cache_base = os.environ.get("LOCALAPPDATA", os.path.expanduser("~"))
+        cache_dir = os.path.join(cache_base, "kicad-mcp", "cache")
+    else:  # Linux/macOS
+        cache_base = os.environ.get("XDG_CACHE_HOME", os.path.expanduser("~/.cache"))
+        cache_dir = os.path.join(cache_base, "kicad-mcp")
+
+    os.makedirs(cache_dir, exist_ok=True)
+    return cache_dir
+
+
+def get_cache_path() -> str:
+    """Get the footprint index cache file path.
+
+    Returns:
+        Full path to footprint_index.json
+    """
+    return os.path.join(get_cache_dir(), "footprint_index.json")
+
+
+def get_lock_path() -> str:
+    """Get the lock file path for cache operations.
+
+    Returns:
+        Full path to footprint_index.lock
+    """
+    return os.path.join(get_cache_dir(), "footprint_index.lock")
+
+
+def compute_library_hash(library_path: str) -> str:
+    """Compute hash of library directory to detect changes.
+
+    Args:
+        library_path: Path to KiCad footprints directory
+
+    Returns:
+        MD5 hash of all .pretty directory modification times
+    """
+    if not os.path.exists(library_path):
+        return ""
+
+    hash_input = []
+    for dirname in sorted(os.listdir(library_path)):
+        if dirname.endswith(".pretty"):
+            dirpath = os.path.join(library_path, dirname)
+            if os.path.isdir(dirpath):
+                # Use directory mtime and count of .kicad_mod files
+                mtime = os.path.getmtime(dirpath)
+                mod_count = len([f for f in os.listdir(dirpath) if f.endswith(".kicad_mod")])
+                hash_input.append(f"{dirname}:{mtime}:{mod_count}")
+
+    combined = "|".join(hash_input)
+    return hashlib.md5(combined.encode()).hexdigest()
+
+
+def is_cache_valid(cache_data: dict[str, Any], library_path: str) -> bool:
+    """Check if cached index is still valid.
+
+    Args:
+        cache_data: Loaded cache data
+        library_path: Current KiCad footprints directory path
+
+    Returns:
+        True if cache is valid, False if needs rebuild
+    """
+    # Check version
+    if cache_data.get("version") != 1:
+        return False
+
+    # Check if library path changed
+    if cache_data.get("library_path") != library_path:
+        return False
+
+    # Check if library directories changed
+    current_hash = compute_library_hash(library_path)
+    cached_hash: str = cache_data.get("library_hash", "")
+
+    return current_hash == cached_hash
+
+
+def load_footprint_index() -> dict[str, Any] | None:
+    """Load footprint index from cache.
+
+    Returns:
+        Cached index data, or None if cache doesn't exist
+    """
+    cache_path = get_cache_path()
+
+    if not os.path.exists(cache_path):
+        return None
+
+    try:
+        with open(cache_path, encoding="utf-8") as f:
+            data: dict[str, Any] = json.load(f)
+            return data
+    except Exception as e:
+        logger.warning(f"Error loading footprint cache: {e}")
+        return None
+
+
+def save_footprint_index(index_data: dict[str, Any]) -> bool:
+    """Save footprint index to cache with file locking.
+
+    Args:
+        index_data: Index data to save
+
+    Returns:
+        True if saved successfully, False otherwise
+    """
+    cache_path = get_cache_path()
+    lock = FileLock(get_lock_path(), timeout=300)
+
+    try:
+        with lock:
+            with open(cache_path, "w", encoding="utf-8") as f:
+                json.dump(index_data, f, indent=2)
+            logger.info(f"Footprint index saved to: {cache_path}")
+        return True
+    except Timeout:
+        logger.error("Timeout waiting for cache lock")
+        return False
+    except Exception as e:
+        logger.error(f"Error saving footprint cache: {e}")
+        return False
+
+
+def _process_library(lib_name: str, lib_path: str, parse_func) -> list[dict[str, Any]]:
+    """Process a single library directory. Used by ThreadPoolExecutor."""
+    try:
+        footprints = parse_func(lib_path)
+        return [
+            {
+                "library": lib_name,
+                "name": fp["name"],
+                "description": fp["description"],
+                "keywords": fp["keywords"],
+                "id": f"{lib_name}:{fp['name']}",
+            }
+            for fp in footprints
+        ]
+    except Exception as e:
+        logger.error(f"Error processing library {lib_name}: {e}")
+        return []
+
+
+async def build_footprint_index_data(library_path: str, ctx=None) -> dict[str, Any]:
+    """Build footprint index data structure using parallel I/O.
+
+    Args:
+        library_path: Path to KiCad footprints directory
+        ctx: Optional MCP context for progress reporting
+
+    Returns:
+        Index data structure ready to cache
+    """
+    import importlib
+
+    ft = importlib.import_module("kicad_mcp.tools.footprint_tools")
+
+    logger.info(f"Building footprint index from: {library_path}")
+
+    libraries = ft.list_available_libraries()
+    total = len(libraries)
+    footprints = []
+
+    logger.info(f"Indexing {total} libraries (parallel)...")
+
+    # Use ThreadPoolExecutor for parallel directory I/O
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        futures = {
+            executor.submit(
+                _process_library,
+                lib_name,
+                os.path.join(library_path, f"{lib_name}.pretty"),
+                ft.get_all_footprints_in_library,
+            ): lib_name
+            for lib_name in libraries
+        }
+
+        for completed, future in enumerate(as_completed(futures), 1):
+            if completed % 20 == 0:
+                logger.debug(f"Processed {completed}/{total} libraries...")
+
+            if ctx:
+                progress = int((completed / total) * 90) + 5
+                await ctx.report_progress(progress, 100)
+
+            lib_footprints = future.result()
+            footprints.extend(lib_footprints)
+
+    logger.info(f"Indexed {len(footprints)} footprints from {total} libraries")
+
+    index_data = {
+        "version": 1,
+        "timestamp": datetime.utcnow().isoformat(),
+        "library_path": library_path,
+        "library_hash": compute_library_hash(library_path),
+        "footprint_count": len(footprints),
+        "library_count": len(libraries),
+        "footprints": footprints,
+    }
+
+    return index_data
+
+
+async def get_or_build_index(
+    library_path: str, force_rebuild: bool = False, ctx=None
+) -> dict[str, Any]:
+    """Get footprint index, building if needed.
+
+    Args:
+        library_path: Path to KiCad footprints directory
+        force_rebuild: Force rebuild even if cache is valid
+        ctx: Optional MCP context for progress reporting
+
+    Returns:
+        Footprint index data
+    """
+    if ctx:
+        await ctx.report_progress(1, 100)
+
+    if not force_rebuild:
+        cached = load_footprint_index()
+        if cached and is_cache_valid(cached, library_path):
+            logger.debug(f"Using cached footprint index ({cached['footprint_count']} footprints)")
+            if ctx:
+                await ctx.report_progress(100, 100)
+            return cached
+
+    logger.info("Footprint index cache invalid or missing, rebuilding...")
+
+    index_data = await build_footprint_index_data(library_path, ctx)
+
+    # Save to cache
+    save_footprint_index(index_data)
+
+    if ctx:
+        await ctx.report_progress(100, 100)
+
+    return index_data
+
+
+def search_index(
+    index_data: dict[str, Any], query: str, library: str | None = None, limit: int = 20
+) -> dict[str, Any]:
+    """Search the footprint index.
+
+    Args:
+        index_data: Footprint index data
+        query: Search query
+        library: Optional library filter
+        limit: Maximum results (0 for count only)
+
+    Returns:
+        Dict with total_matches, results list, and truncated flag
+    """
+    query_lower = query.lower()
+    results = []
+
+    for fp in index_data["footprints"]:
+        if library and fp["library"] != library:
+            continue
+
+        searchable = f"{fp['name']} {fp['description']} {fp['keywords']}".lower()
+
+        if query_lower in searchable:
+            score = 0
+            if query_lower in fp["name"].lower():
+                score += 10
+            if query_lower in fp["description"].lower():
+                score += 5
+            if query_lower in fp["keywords"].lower():
+                score += 3
+
+            results.append(
+                {
+                    "footprint": fp["id"],
+                    "description": fp["description"],
+                    "keywords": fp["keywords"],
+                    "_score": score,
+                }
+            )
+
+    results.sort(key=lambda x: x["_score"], reverse=True)
+    total_matches = len(results)
+    truncated = total_matches > limit and limit > 0
+
+    if limit > 0:
+        results = results[:limit]
+
+    for r in results:
+        del r["_score"]
+
+    return {"total_matches": total_matches, "truncated": truncated, "results": results}

--- a/kicad_mcp/utils/symbol_cache.py
+++ b/kicad_mcp/utils/symbol_cache.py
@@ -1,0 +1,319 @@
+"""
+Symbol index cache management for fast symbol searches.
+
+Builds and maintains a cached index of all KiCad symbols to avoid
+parsing 223 library files on every search.
+"""
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime
+import hashlib
+import json
+import logging
+import os
+from typing import Any
+
+from filelock import FileLock, Timeout
+
+logger = logging.getLogger(__name__)
+
+
+def get_cache_dir() -> str:
+    """Get the cache directory path.
+
+    Returns:
+        Path to cache directory (created if doesn't exist)
+    """
+    if os.name == "nt":  # Windows
+        cache_base = os.environ.get("LOCALAPPDATA", os.path.expanduser("~"))
+        cache_dir = os.path.join(cache_base, "kicad-mcp", "cache")
+    else:  # Linux/macOS
+        cache_base = os.environ.get("XDG_CACHE_HOME", os.path.expanduser("~/.cache"))
+        cache_dir = os.path.join(cache_base, "kicad-mcp")
+
+    os.makedirs(cache_dir, exist_ok=True)
+    return cache_dir
+
+
+def get_cache_path() -> str:
+    """Get the symbol index cache file path.
+
+    Returns:
+        Full path to symbol_index.json
+    """
+    return os.path.join(get_cache_dir(), "symbol_index.json")
+
+
+def get_lock_path() -> str:
+    """Get the lock file path for cache operations.
+
+    Returns:
+        Full path to symbol_index.lock
+    """
+    return os.path.join(get_cache_dir(), "symbol_index.lock")
+
+
+def compute_library_hash(library_path: str) -> str:
+    """Compute hash of library directory to detect changes.
+
+    Args:
+        library_path: Path to KiCad symbols directory
+
+    Returns:
+        MD5 hash of all .kicad_sym file modification times
+    """
+    if not os.path.exists(library_path):
+        return ""
+
+    hash_input = []
+    for filename in sorted(os.listdir(library_path)):
+        if filename.endswith(".kicad_sym"):
+            filepath = os.path.join(library_path, filename)
+            mtime = os.path.getmtime(filepath)
+            hash_input.append(f"{filename}:{mtime}")
+
+    combined = "|".join(hash_input)
+    return hashlib.md5(combined.encode()).hexdigest()
+
+
+def is_cache_valid(cache_data: dict[str, Any], library_path: str) -> bool:
+    """Check if cached index is still valid.
+
+    Args:
+        cache_data: Loaded cache data
+        library_path: Current KiCad symbols directory path
+
+    Returns:
+        True if cache is valid, False if needs rebuild
+    """
+    # Check version
+    if cache_data.get("version") != 1:
+        return False
+
+    # Check if library path changed
+    if cache_data.get("library_path") != library_path:
+        return False
+
+    # Check if library files changed
+    current_hash = compute_library_hash(library_path)
+    cached_hash: str = cache_data.get("library_hash", "")
+
+    return current_hash == cached_hash
+
+
+def load_symbol_index() -> dict[str, Any] | None:
+    """Load symbol index from cache.
+
+    Returns:
+        Cached index data, or None if cache doesn't exist
+    """
+    cache_path = get_cache_path()
+
+    if not os.path.exists(cache_path):
+        return None
+
+    try:
+        with open(cache_path, encoding="utf-8") as f:
+            data: dict[str, Any] = json.load(f)
+            return data
+    except Exception as e:
+        logger.warning(f"Error loading symbol cache: {e}")
+        return None
+
+
+def save_symbol_index(index_data: dict[str, Any]) -> bool:
+    """Save symbol index to cache with file locking.
+
+    Args:
+        index_data: Index data to save
+
+    Returns:
+        True if saved successfully, False otherwise
+    """
+    cache_path = get_cache_path()
+    lock = FileLock(get_lock_path(), timeout=300)
+
+    try:
+        with lock:
+            with open(cache_path, "w", encoding="utf-8") as f:
+                json.dump(index_data, f, indent=2)
+            logger.info(f"Symbol index saved to: {cache_path}")
+        return True
+    except Timeout:
+        logger.error("Timeout waiting for cache lock")
+        return False
+    except Exception as e:
+        logger.error(f"Error saving symbol cache: {e}")
+        return False
+
+
+def _process_library(lib_name: str, read_func, parse_func) -> list[dict[str, Any]]:
+    """Process a single library file. Used by ThreadPoolExecutor."""
+    try:
+        lib_content = read_func(lib_name)
+        if lib_content is None:
+            logger.debug(f"Library not found: {lib_name}")
+            return []
+
+        lib_symbols = parse_func(lib_content)
+        return [
+            {
+                "library": lib_name,
+                "name": sym["name"],
+                "description": sym["description"],
+                "keywords": sym["keywords"],
+                "id": f"{lib_name}:{sym['name']}",
+            }
+            for sym in lib_symbols
+        ]
+    except Exception as e:
+        logger.error(f"Error processing library {lib_name}: {e}")
+        return []
+
+
+async def build_symbol_index_data(library_path: str, ctx=None) -> dict[str, Any]:
+    """Build symbol index data structure using parallel I/O.
+
+    Args:
+        library_path: Path to KiCad symbols directory
+        ctx: Optional MCP context for progress reporting
+
+    Returns:
+        Index data structure ready to cache
+    """
+    import importlib
+
+    st = importlib.import_module("kicad_mcp.tools.symbol_tools")
+
+    logger.info(f"Building symbol index from: {library_path}")
+
+    libraries = st.list_available_libraries()
+    total = len(libraries)
+    symbols = []
+
+    logger.info(f"Indexing {total} libraries (parallel)...")
+
+    # Use ThreadPoolExecutor for parallel file I/O
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        futures = {
+            executor.submit(
+                _process_library, lib_name, st.read_library_file, st.get_all_symbols_in_library
+            ): lib_name
+            for lib_name in libraries
+        }
+
+        for completed, future in enumerate(as_completed(futures), 1):
+            if completed % 20 == 0:
+                logger.debug(f"Processed {completed}/{total} libraries...")
+
+            if ctx:
+                progress = int((completed / total) * 90) + 5
+                await ctx.report_progress(progress, 100)
+
+            lib_symbols = future.result()
+            symbols.extend(lib_symbols)
+
+    logger.info(f"Indexed {len(symbols)} symbols from {total} libraries")
+
+    index_data = {
+        "version": 1,
+        "timestamp": datetime.utcnow().isoformat(),
+        "library_path": library_path,
+        "library_hash": compute_library_hash(library_path),
+        "symbol_count": len(symbols),
+        "library_count": len(libraries),
+        "symbols": symbols,
+    }
+
+    return index_data
+
+
+async def get_or_build_index(
+    library_path: str, force_rebuild: bool = False, ctx=None
+) -> dict[str, Any]:
+    """Get symbol index, building if needed.
+
+    Args:
+        library_path: Path to KiCad symbols directory
+        force_rebuild: Force rebuild even if cache is valid
+        ctx: Optional MCP context for progress reporting
+
+    Returns:
+        Symbol index data
+    """
+    if ctx:
+        await ctx.report_progress(1, 100)
+
+    if not force_rebuild:
+        cached = load_symbol_index()
+        if cached and is_cache_valid(cached, library_path):
+            logger.debug(f"Using cached symbol index ({cached['symbol_count']} symbols)")
+            if ctx:
+                await ctx.report_progress(100, 100)
+            return cached
+
+    logger.info("Symbol index cache invalid or missing, rebuilding...")
+
+    index_data = await build_symbol_index_data(library_path, ctx)
+
+    # Save to cache
+    save_symbol_index(index_data)
+
+    if ctx:
+        await ctx.report_progress(100, 100)
+
+    return index_data
+
+
+def search_index(
+    index_data: dict[str, Any], query: str, library: str | None = None, limit: int = 20
+) -> dict[str, Any]:
+    """Search the symbol index.
+
+    Args:
+        index_data: Symbol index data
+        query: Search query
+        library: Optional library filter
+        limit: Maximum results (0 for count only)
+
+    Returns:
+        Dict with total_matches, results list, and truncated flag
+    """
+    query_lower = query.lower()
+    results = []
+
+    for sym in index_data["symbols"]:
+        if library and sym["library"] != library:
+            continue
+
+        searchable = f"{sym['name']} {sym['description']} {sym['keywords']}".lower()
+
+        if query_lower in searchable:
+            score = 0
+            if query_lower in sym["name"].lower():
+                score += 10
+            if query_lower in sym["description"].lower():
+                score += 5
+            if query_lower in sym["keywords"].lower():
+                score += 3
+
+            results.append(
+                {
+                    "symbol": sym["id"],
+                    "description": sym["description"],
+                    "keywords": sym["keywords"],
+                    "_score": score,
+                }
+            )
+
+    results.sort(key=lambda x: x["_score"], reverse=True)
+    total_matches = len(results)
+    truncated = total_matches > limit and limit > 0
+
+    if limit > 0:
+        results = results[:limit]
+
+    for r in results:
+        del r["_score"]
+
+    return {"total_matches": total_matches, "truncated": truncated, "results": results}

--- a/main.py
+++ b/main.py
@@ -35,7 +35,7 @@ _PID = os.getpid()
 # This attempts to update os.environ
 dotenv_path = os.path.join(os.path.dirname(__file__), '.env')
 logging.info(f"Attempting to load .env file from: {dotenv_path}")
-found_dotenv = load_dotenv() # Assuming this returns True/False or similar
+found_dotenv = load_dotenv(dotenv_path) # Assuming this returns True/False or similar
 logging.info(f".env file found and loaded: {found_dotenv}")
 
 # Log effective values AFTER load_dotenv attempt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "pandas>=2.0.0",
     "pyyaml>=6.0.0",
     "defusedxml>=0.7.0",  # Secure XML parsing
+    "filelock>=3.0.0",  # Cross-platform file locking
 ]
 
 [project.urls]

--- a/tests/unit/tools/test_footprint_tools.py
+++ b/tests/unit/tools/test_footprint_tools.py
@@ -1,0 +1,194 @@
+"""Unit tests for footprint_tools module."""
+
+from unittest.mock import patch
+
+import pytest
+
+from kicad_mcp.tools.footprint_tools import (
+    find_similar_footprints,
+    get_all_footprints_in_library,
+    list_available_libraries,
+    parse_footprint_identifier,
+    parse_pads_from_footprint,
+    read_footprint_file,
+)
+
+
+class TestParseFootprintIdentifier:
+    """Tests for parse_footprint_identifier function."""
+
+    def test_valid_identifier(self):
+        lib, fp = parse_footprint_identifier("Resistor_SMD:R_0805_2012Metric")
+        assert lib == "Resistor_SMD"
+        assert fp == "R_0805_2012Metric"
+
+    def test_valid_identifier_with_colon_in_name(self):
+        lib, fp = parse_footprint_identifier("Library:Footprint:WithColon")
+        assert lib == "Library"
+        assert fp == "Footprint:WithColon"
+
+    def test_missing_colon_raises_error(self):
+        with pytest.raises(ValueError, match="Invalid footprint identifier"):
+            parse_footprint_identifier("InvalidFormat")
+
+    def test_empty_string_raises_error(self):
+        with pytest.raises(ValueError, match="Invalid footprint identifier"):
+            parse_footprint_identifier("")
+
+
+class TestParsePadsFromFootprint:
+    """Tests for parse_pads_from_footprint function."""
+
+    def test_parse_smd_pad(self):
+        content = """(footprint "R_0805"
+            (pad "1" smd rect (at -1 0) (size 1 1.2))
+            (pad "2" smd rect (at 1 0) (size 1 1.2))
+        )"""
+        pads = parse_pads_from_footprint(content)
+        assert len(pads) == 2
+        assert pads[0]["number"] == "1"
+        assert pads[0]["type"] == "smd"
+        assert pads[0]["shape"] == "rect"
+        assert pads[0]["position"] == [-1.0, 0.0]
+
+    def test_parse_thru_hole_pad_with_drill(self):
+        content = """(footprint "DIP-8"
+            (pad "1" thru_hole circle (at 0 0) (size 1.6 1.6) (drill 0.8))
+        )"""
+        pads = parse_pads_from_footprint(content)
+        assert len(pads) == 1
+        assert pads[0]["type"] == "thru_hole"
+        assert pads[0]["drill"] == [0.8, 0.8]
+
+    def test_parse_pad_with_angle(self):
+        content = """(footprint "Rotated"
+            (pad "1" smd rect (at 1.5 0 45) (size 1 1))
+        )"""
+        pads = parse_pads_from_footprint(content)
+        assert len(pads) == 1
+        assert pads[0]["angle"] == 45.0
+
+    def test_empty_footprint(self):
+        content = "(footprint \"Empty\")"
+        pads = parse_pads_from_footprint(content)
+        assert pads == []
+
+
+class TestGetAllFootprintsInLibrary:
+    """Tests for get_all_footprints_in_library function."""
+
+    def test_returns_empty_for_nonexistent_path(self):
+        result = get_all_footprints_in_library("/nonexistent/path")
+        assert result == []
+
+    @patch("os.path.exists")
+    @patch("os.listdir")
+    @patch("builtins.open")
+    def test_parses_footprint_files(self, mock_open, mock_listdir, mock_exists):
+        mock_exists.return_value = True
+        mock_listdir.return_value = ["R_0805.kicad_mod", "C_0603.kicad_mod"]
+
+        mock_open.return_value.__enter__.return_value.read.return_value = """
+        (footprint "R_0805"
+            (descr "Resistor SMD 0805")
+            (tags "resistor 0805 SMD")
+        )
+        """
+
+        result = get_all_footprints_in_library("/fake/path")
+        assert len(result) == 2
+
+    @patch("os.path.exists")
+    @patch("os.listdir")
+    def test_filters_non_kicad_mod_files(self, mock_listdir, mock_exists):
+        mock_exists.return_value = True
+        mock_listdir.return_value = ["valid.kicad_mod", "readme.txt", "other.lib"]
+
+        with patch("builtins.open") as mock_open:
+            mock_open.return_value.__enter__.return_value.read.return_value = "(footprint \"test\")"
+            result = get_all_footprints_in_library("/fake/path")
+            # Only the .kicad_mod file should be processed
+            assert mock_open.call_count == 1
+
+
+class TestListAvailableLibraries:
+    """Tests for list_available_libraries function."""
+
+    @patch("kicad_mcp.tools.footprint_tools.get_footprint_library_path")
+    @patch("os.path.exists")
+    @patch("os.listdir")
+    @patch("os.path.isdir")
+    def test_returns_sorted_libraries(self, mock_isdir, mock_listdir, mock_exists, mock_path):
+        mock_path.return_value = "/fake/path"
+        mock_exists.return_value = True
+        mock_listdir.return_value = ["Zebra.pretty", "Apple.pretty", "Mango.pretty"]
+        mock_isdir.return_value = True
+
+        libs = list_available_libraries()
+        assert libs == ["Apple", "Mango", "Zebra"]
+
+    @patch("kicad_mcp.tools.footprint_tools.get_footprint_library_path")
+    @patch("os.path.exists")
+    def test_returns_empty_if_path_not_exists(self, mock_exists, mock_path):
+        mock_path.return_value = "/fake/path"
+        mock_exists.return_value = False
+
+        libs = list_available_libraries()
+        assert libs == []
+
+    @patch("kicad_mcp.tools.footprint_tools.get_footprint_library_path")
+    @patch("os.path.exists")
+    @patch("os.listdir")
+    @patch("os.path.isdir")
+    def test_filters_non_pretty_directories(self, mock_isdir, mock_listdir, mock_exists, mock_path):
+        mock_path.return_value = "/fake/path"
+        mock_exists.return_value = True
+        mock_listdir.return_value = ["Valid.pretty", "readme.txt", "other.lib"]
+        mock_isdir.return_value = True
+
+        libs = list_available_libraries()
+        assert libs == ["Valid"]
+
+
+class TestFindSimilarFootprints:
+    """Tests for find_similar_footprints function."""
+
+    def test_exact_substring_match(self):
+        footprints = ["R_0805_2012Metric", "R_0603_1608Metric", "C_0805_2012Metric"]
+        similar = find_similar_footprints("0805", footprints)
+        assert "R_0805_2012Metric" in similar
+        assert "C_0805_2012Metric" in similar
+
+    def test_limit_results(self):
+        footprints = [f"Footprint{i}" for i in range(20)]
+        similar = find_similar_footprints("Footprint", footprints, limit=5)
+        assert len(similar) == 5
+
+    def test_fuzzy_match(self):
+        footprints = ["SOIC-8", "SSOP-8", "DIP-8"]
+        similar = find_similar_footprints("SOIC", footprints)
+        assert "SOIC-8" in similar
+
+
+class TestReadFootprintFile:
+    """Tests for read_footprint_file function."""
+
+    @patch("kicad_mcp.tools.footprint_tools.get_footprint_library_path")
+    @patch("os.path.exists")
+    def test_returns_none_if_not_found(self, mock_exists, mock_path):
+        mock_path.return_value = "/fake/path"
+        mock_exists.return_value = False
+
+        result = read_footprint_file("NonExistent", "Footprint")
+        assert result is None
+
+    @patch("kicad_mcp.tools.footprint_tools.get_footprint_library_path")
+    @patch("os.path.exists")
+    @patch("builtins.open")
+    def test_reads_file_content(self, mock_open, mock_exists, mock_path):
+        mock_path.return_value = "/fake/path"
+        mock_exists.return_value = True
+        mock_open.return_value.__enter__.return_value.read.return_value = "(footprint content)"
+
+        result = read_footprint_file("Resistor_SMD", "R_0805")
+        assert result == "(footprint content)"

--- a/tests/unit/tools/test_symbol_tools.py
+++ b/tests/unit/tools/test_symbol_tools.py
@@ -1,0 +1,152 @@
+"""Unit tests for symbol_tools module."""
+
+from unittest.mock import patch
+
+import pytest
+
+from kicad_mcp.tools.symbol_tools import (
+    find_similar_symbols,
+    get_all_symbols_in_library,
+    list_available_libraries,
+    parse_symbol_identifier,
+    read_library_file,
+)
+
+
+class TestParseSymbolIdentifier:
+    """Tests for parse_symbol_identifier function."""
+
+    def test_valid_identifier(self):
+        lib, sym = parse_symbol_identifier("Device:R")
+        assert lib == "Device"
+        assert sym == "R"
+
+    def test_valid_identifier_with_colon_in_name(self):
+        lib, sym = parse_symbol_identifier("Library:Symbol:WithColon")
+        assert lib == "Library"
+        assert sym == "Symbol:WithColon"
+
+    def test_missing_colon_raises_error(self):
+        with pytest.raises(ValueError, match="Invalid symbol identifier"):
+            parse_symbol_identifier("InvalidFormat")
+
+    def test_empty_string_raises_error(self):
+        with pytest.raises(ValueError, match="Invalid symbol identifier"):
+            parse_symbol_identifier("")
+
+
+class TestGetAllSymbolsInLibrary:
+    """Tests for get_all_symbols_in_library function."""
+
+    def test_parse_simple_symbol(self):
+        content = """(kicad_symbol_lib
+	(symbol "R"
+		(property "Description" "Resistor")
+		(property "ki_keywords" "resistor R")
+	)
+)"""
+        symbols = get_all_symbols_in_library(content)
+        assert len(symbols) == 1
+        assert symbols[0]["name"] == "R"
+        assert symbols[0]["description"] == "Resistor"
+        assert symbols[0]["keywords"] == "resistor R"
+
+    def test_skip_internal_units(self):
+        content = """(kicad_symbol_lib
+	(symbol "IC1"
+		(property "Description" "Main chip")
+	)
+	(symbol "IC1_0_1"
+		(property "Description" "Internal unit")
+	)
+	(symbol "IC1_1_1"
+		(property "Description" "Another internal unit")
+	)
+)"""
+        symbols = get_all_symbols_in_library(content)
+        assert len(symbols) == 1
+        assert symbols[0]["name"] == "IC1"
+
+    def test_empty_library(self):
+        content = "(kicad_symbol_lib)"
+        symbols = get_all_symbols_in_library(content)
+        assert symbols == []
+
+    def test_missing_description(self):
+        content = """(kicad_symbol_lib
+	(symbol "NoDesc"
+		(property "ki_keywords" "test")
+	)
+)"""
+        symbols = get_all_symbols_in_library(content)
+        assert len(symbols) == 1
+        assert symbols[0]["description"] == ""
+        assert symbols[0]["keywords"] == "test"
+
+
+class TestListAvailableLibraries:
+    """Tests for list_available_libraries function."""
+
+    @patch("kicad_mcp.tools.symbol_tools.get_symbol_library_path")
+    @patch("os.path.exists")
+    @patch("os.listdir")
+    def test_returns_sorted_libraries(self, mock_listdir, mock_exists, mock_path):
+        mock_path.return_value = "/fake/path"
+        mock_exists.return_value = True
+        mock_listdir.return_value = ["Zebra.kicad_sym", "Apple.kicad_sym", "Mango.kicad_sym"]
+
+        libs = list_available_libraries()
+        assert libs == ["Apple", "Mango", "Zebra"]
+
+    @patch("kicad_mcp.tools.symbol_tools.get_symbol_library_path")
+    @patch("os.path.exists")
+    def test_returns_empty_if_path_not_exists(self, mock_exists, mock_path):
+        mock_path.return_value = "/fake/path"
+        mock_exists.return_value = False
+
+        libs = list_available_libraries()
+        assert libs == []
+
+    @patch("kicad_mcp.tools.symbol_tools.get_symbol_library_path")
+    @patch("os.path.exists")
+    @patch("os.listdir")
+    def test_filters_non_kicad_files(self, mock_listdir, mock_exists, mock_path):
+        mock_path.return_value = "/fake/path"
+        mock_exists.return_value = True
+        mock_listdir.return_value = ["Valid.kicad_sym", "readme.txt", "other.lib"]
+
+        libs = list_available_libraries()
+        assert libs == ["Valid"]
+
+
+class TestFindSimilarSymbols:
+    """Tests for find_similar_symbols function."""
+
+    def test_exact_substring_match(self):
+        symbols = ["ATmega328", "ATmega168", "PIC16F84", "STM32F4"]
+        similar = find_similar_symbols("mega", symbols)
+        assert "ATmega328" in similar
+        assert "ATmega168" in similar
+
+    def test_limit_results(self):
+        symbols = [f"Symbol{i}" for i in range(20)]
+        similar = find_similar_symbols("Symbol", symbols, limit=5)
+        assert len(similar) == 5
+
+    def test_fuzzy_match(self):
+        symbols = ["Resistor", "Capacitor", "Inductor"]
+        similar = find_similar_symbols("Resist", symbols)
+        assert "Resistor" in similar
+
+
+class TestReadLibraryFile:
+    """Tests for read_library_file function."""
+
+    @patch("kicad_mcp.tools.symbol_tools.get_symbol_library_path")
+    @patch("os.path.exists")
+    def test_returns_none_if_not_found(self, mock_exists, mock_path):
+        mock_path.return_value = "/fake/path"
+        mock_exists.return_value = False
+
+        result = read_library_file("NonExistent")
+        assert result is None

--- a/tests/unit/utils/test_footprint_cache.py
+++ b/tests/unit/utils/test_footprint_cache.py
@@ -1,0 +1,220 @@
+"""Unit tests for footprint_cache module."""
+
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kicad_mcp.utils.footprint_cache import (
+    _process_library,
+    compute_library_hash,
+    get_cache_dir,
+    get_cache_path,
+    get_lock_path,
+    is_cache_valid,
+    load_footprint_index,
+    save_footprint_index,
+    search_index,
+)
+
+
+class TestCachePaths:
+    """Tests for cache path functions."""
+
+    def test_get_cache_dir_creates_directory(self):
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            patch.dict(os.environ, {"XDG_CACHE_HOME": temp_dir}),
+        ):
+            cache_dir = get_cache_dir()
+            assert os.path.exists(cache_dir)
+            assert "kicad-mcp" in cache_dir
+
+    def test_get_cache_path_returns_json_path(self):
+        path = get_cache_path()
+        assert path.endswith("footprint_index.json")
+
+    def test_get_lock_path_returns_lock_path(self):
+        path = get_lock_path()
+        assert path.endswith("footprint_index.lock")
+
+
+class TestComputeLibraryHash:
+    """Tests for compute_library_hash function."""
+
+    def test_returns_empty_for_nonexistent_path(self):
+        result = compute_library_hash("/nonexistent/path")
+        assert result == ""
+
+    def test_returns_consistent_hash(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create a .pretty directory with a .kicad_mod file
+            pretty_dir = os.path.join(temp_dir, "Test.pretty")
+            os.makedirs(pretty_dir)
+            mod_file = os.path.join(pretty_dir, "Test.kicad_mod")
+            with open(mod_file, "w") as f:
+                f.write("test content")
+
+            hash1 = compute_library_hash(temp_dir)
+            hash2 = compute_library_hash(temp_dir)
+            assert hash1 == hash2
+            assert len(hash1) == 32  # MD5 hex length
+
+    def test_ignores_non_pretty_directories(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create a non-.pretty directory
+            other_dir = os.path.join(temp_dir, "Other")
+            os.makedirs(other_dir)
+
+            # Hash should be the MD5 of empty string since no .pretty directories
+            result = compute_library_hash(temp_dir)
+            # MD5 of empty string
+            assert result == "d41d8cd98f00b204e9800998ecf8427e"
+
+
+class TestIsCacheValid:
+    """Tests for is_cache_valid function."""
+
+    def test_invalid_version(self):
+        cache_data = {"version": 999, "library_path": "/path", "library_hash": "abc"}
+        assert is_cache_valid(cache_data, "/path") is False
+
+    def test_invalid_library_path(self):
+        cache_data = {"version": 1, "library_path": "/old/path", "library_hash": "abc"}
+        assert is_cache_valid(cache_data, "/new/path") is False
+
+    def test_stale_hash(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cache_data = {"version": 1, "library_path": temp_dir, "library_hash": "stale_hash"}
+            assert is_cache_valid(cache_data, temp_dir) is False
+
+    def test_valid_cache(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create a .pretty directory
+            pretty_dir = os.path.join(temp_dir, "Test.pretty")
+            os.makedirs(pretty_dir)
+            mod_file = os.path.join(pretty_dir, "Test.kicad_mod")
+            with open(mod_file, "w") as f:
+                f.write("test content")
+
+            current_hash = compute_library_hash(temp_dir)
+            cache_data = {"version": 1, "library_path": temp_dir, "library_hash": current_hash}
+            assert is_cache_valid(cache_data, temp_dir) is True
+
+
+class TestLoadSaveFootprintIndex:
+    """Tests for load and save functions."""
+
+    def test_load_returns_none_if_not_exists(self):
+        with patch("kicad_mcp.utils.footprint_cache.get_cache_path") as mock_path:
+            mock_path.return_value = "/nonexistent/path/cache.json"
+            result = load_footprint_index()
+            assert result is None
+
+    def test_save_and_load_roundtrip(self):
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            patch("kicad_mcp.utils.footprint_cache.get_cache_path") as mock_path,
+            patch("kicad_mcp.utils.footprint_cache.get_lock_path") as mock_lock,
+        ):
+            cache_file = os.path.join(temp_dir, "test_cache.json")
+            mock_path.return_value = cache_file
+            mock_lock.return_value = os.path.join(temp_dir, "test.lock")
+
+            test_data = {"version": 1, "footprints": [], "footprint_count": 0}
+            assert save_footprint_index(test_data) is True
+
+            loaded = load_footprint_index()
+            assert loaded["version"] == 1
+            assert loaded["footprint_count"] == 0
+
+
+class TestSearchIndex:
+    """Tests for search_index function."""
+
+    @pytest.fixture
+    def sample_index(self):
+        return {
+            "footprints": [
+                {
+                    "id": "Resistor_SMD:R_0805_2012Metric",
+                    "name": "R_0805_2012Metric",
+                    "library": "Resistor_SMD",
+                    "description": "Resistor SMD 0805",
+                    "keywords": "resistor 0805 SMD",
+                },
+                {
+                    "id": "Capacitor_SMD:C_0805_2012Metric",
+                    "name": "C_0805_2012Metric",
+                    "library": "Capacitor_SMD",
+                    "description": "Capacitor SMD 0805",
+                    "keywords": "capacitor 0805 SMD",
+                },
+                {
+                    "id": "Package_SO:SOIC-8_3.9x4.9mm_P1.27mm",
+                    "name": "SOIC-8_3.9x4.9mm_P1.27mm",
+                    "library": "Package_SO",
+                    "description": "SOIC 8 pin package",
+                    "keywords": "SOIC SO IC",
+                },
+            ]
+        }
+
+    def test_basic_search(self, sample_index):
+        result = search_index(sample_index, "Resistor")
+        assert result["total_matches"] == 1
+        assert result["results"][0]["footprint"] == "Resistor_SMD:R_0805_2012Metric"
+
+    def test_library_filter(self, sample_index):
+        result = search_index(sample_index, "0805", library="Resistor_SMD")
+        assert result["total_matches"] == 1
+        assert result["results"][0]["footprint"] == "Resistor_SMD:R_0805_2012Metric"
+
+    def test_truncation(self, sample_index):
+        result = search_index(sample_index, "0", limit=1)  # matches multiple
+        assert result["truncated"] is True
+        assert len(result["results"]) == 1
+
+    def test_no_truncation_when_under_limit(self, sample_index):
+        result = search_index(sample_index, "SOIC", limit=10)
+        assert result["truncated"] is False
+
+    def test_case_insensitive(self, sample_index):
+        result = search_index(sample_index, "RESISTOR")
+        assert result["total_matches"] == 1
+
+    def test_no_matches(self, sample_index):
+        result = search_index(sample_index, "nonexistent")
+        assert result["total_matches"] == 0
+        assert result["results"] == []
+
+    def test_search_by_keywords(self, sample_index):
+        result = search_index(sample_index, "SMD")
+        assert result["total_matches"] == 2  # Both resistor and capacitor have SMD
+
+
+class TestProcessLibrary:
+    """Tests for _process_library function."""
+
+    def test_returns_empty_on_exception(self):
+        parse_func = MagicMock(side_effect=Exception("Parse error"))
+
+        result = _process_library("TestLib", "/fake/path", parse_func)
+        assert result == []
+
+    def test_returns_footprints_on_success(self):
+        parse_func = MagicMock(
+            return_value=[{"name": "FP1", "description": "Desc1", "keywords": "kw1"}]
+        )
+
+        result = _process_library("TestLib", "/fake/path", parse_func)
+        assert len(result) == 1
+        assert result[0]["id"] == "TestLib:FP1"
+        assert result[0]["library"] == "TestLib"
+
+    def test_handles_empty_library(self):
+        parse_func = MagicMock(return_value=[])
+
+        result = _process_library("EmptyLib", "/fake/path", parse_func)
+        assert result == []

--- a/tests/unit/utils/test_symbol_cache.py
+++ b/tests/unit/utils/test_symbol_cache.py
@@ -1,0 +1,192 @@
+"""Unit tests for symbol_cache module."""
+
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kicad_mcp.utils.symbol_cache import (
+    _process_library,
+    compute_library_hash,
+    get_cache_dir,
+    get_cache_path,
+    get_lock_path,
+    is_cache_valid,
+    load_symbol_index,
+    save_symbol_index,
+    search_index,
+)
+
+
+class TestCachePaths:
+    """Tests for cache path functions."""
+
+    def test_get_cache_dir_creates_directory(self):
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            patch.dict(os.environ, {"XDG_CACHE_HOME": temp_dir}),
+        ):
+            cache_dir = get_cache_dir()
+            assert os.path.exists(cache_dir)
+            assert "kicad-mcp" in cache_dir
+
+    def test_get_cache_path_returns_json_path(self):
+        path = get_cache_path()
+        assert path.endswith("symbol_index.json")
+
+    def test_get_lock_path_returns_lock_path(self):
+        path = get_lock_path()
+        assert path.endswith("symbol_index.lock")
+
+
+class TestComputeLibraryHash:
+    """Tests for compute_library_hash function."""
+
+    def test_returns_empty_for_nonexistent_path(self):
+        result = compute_library_hash("/nonexistent/path")
+        assert result == ""
+
+    def test_returns_consistent_hash(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            lib_file = os.path.join(temp_dir, "Test.kicad_sym")
+            with open(lib_file, "w") as f:
+                f.write("test content")
+
+            hash1 = compute_library_hash(temp_dir)
+            hash2 = compute_library_hash(temp_dir)
+            assert hash1 == hash2
+            assert len(hash1) == 32  # MD5 hex length
+
+
+class TestIsCacheValid:
+    """Tests for is_cache_valid function."""
+
+    def test_invalid_version(self):
+        cache_data = {"version": 999, "library_path": "/path", "library_hash": "abc"}
+        assert is_cache_valid(cache_data, "/path") is False
+
+    def test_invalid_library_path(self):
+        cache_data = {"version": 1, "library_path": "/old/path", "library_hash": "abc"}
+        assert is_cache_valid(cache_data, "/new/path") is False
+
+    def test_stale_hash(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cache_data = {"version": 1, "library_path": temp_dir, "library_hash": "stale_hash"}
+            assert is_cache_valid(cache_data, temp_dir) is False
+
+
+class TestLoadSaveSymbolIndex:
+    """Tests for load and save functions."""
+
+    def test_load_returns_none_if_not_exists(self):
+        with patch("kicad_mcp.utils.symbol_cache.get_cache_path") as mock_path:
+            mock_path.return_value = "/nonexistent/path/cache.json"
+            result = load_symbol_index()
+            assert result is None
+
+    def test_save_and_load_roundtrip(self):
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            patch("kicad_mcp.utils.symbol_cache.get_cache_path") as mock_path,
+            patch("kicad_mcp.utils.symbol_cache.get_lock_path") as mock_lock,
+        ):
+            cache_file = os.path.join(temp_dir, "test_cache.json")
+            mock_path.return_value = cache_file
+            mock_lock.return_value = os.path.join(temp_dir, "test.lock")
+
+            test_data = {"version": 1, "symbols": [], "symbol_count": 0}
+            assert save_symbol_index(test_data) is True
+
+            loaded = load_symbol_index()
+            assert loaded["version"] == 1
+            assert loaded["symbol_count"] == 0
+
+
+class TestSearchIndex:
+    """Tests for search_index function."""
+
+    @pytest.fixture
+    def sample_index(self):
+        return {
+            "symbols": [
+                {
+                    "id": "Device:R",
+                    "name": "R",
+                    "library": "Device",
+                    "description": "Resistor",
+                    "keywords": "passive R",
+                },
+                {
+                    "id": "Device:C",
+                    "name": "C",
+                    "library": "Device",
+                    "description": "Capacitor",
+                    "keywords": "passive C",
+                },
+                {
+                    "id": "MCU:ATmega328",
+                    "name": "ATmega328",
+                    "library": "MCU",
+                    "description": "AVR Microcontroller",
+                    "keywords": "AVR MCU",
+                },
+            ]
+        }
+
+    def test_basic_search(self, sample_index):
+        result = search_index(sample_index, "Resistor")
+        assert result["total_matches"] == 1
+        assert result["results"][0]["symbol"] == "Device:R"
+
+    def test_library_filter(self, sample_index):
+        result = search_index(sample_index, "passive", library="Device")
+        assert result["total_matches"] == 2
+
+    def test_truncation(self, sample_index):
+        result = search_index(sample_index, "e", limit=1)  # matches all
+        assert result["truncated"] is True
+        assert len(result["results"]) == 1
+
+    def test_no_truncation_when_under_limit(self, sample_index):
+        result = search_index(sample_index, "ATmega", limit=10)
+        assert result["truncated"] is False
+
+    def test_case_insensitive(self, sample_index):
+        result = search_index(sample_index, "RESISTOR")
+        assert result["total_matches"] == 1
+
+    def test_no_matches(self, sample_index):
+        result = search_index(sample_index, "nonexistent")
+        assert result["total_matches"] == 0
+        assert result["results"] == []
+
+
+class TestProcessLibrary:
+    """Tests for _process_library function."""
+
+    def test_returns_empty_if_read_fails(self):
+        read_func = MagicMock(return_value=None)
+        parse_func = MagicMock()
+
+        result = _process_library("TestLib", read_func, parse_func)
+        assert result == []
+        parse_func.assert_not_called()
+
+    def test_returns_symbols_on_success(self):
+        read_func = MagicMock(return_value="content")
+        parse_func = MagicMock(
+            return_value=[{"name": "Sym1", "description": "Desc1", "keywords": "kw1"}]
+        )
+
+        result = _process_library("TestLib", read_func, parse_func)
+        assert len(result) == 1
+        assert result[0]["id"] == "TestLib:Sym1"
+        assert result[0]["library"] == "TestLib"
+
+    def test_handles_parse_exception(self):
+        read_func = MagicMock(return_value="content")
+        parse_func = MagicMock(side_effect=Exception("Parse error"))
+
+        result = _process_library("TestLib", read_func, parse_func)
+        assert result == []

--- a/uv.lock
+++ b/uv.lock
@@ -759,6 +759,7 @@ source = { editable = "." }
 dependencies = [
     { name = "defusedxml" },
     { name = "fastmcp" },
+    { name = "filelock" },
     { name = "mcp", extra = ["cli"] },
     { name = "pandas" },
     { name = "pyyaml" },
@@ -800,6 +801,7 @@ visualization = [
 requires-dist = [
     { name = "defusedxml", specifier = ">=0.7.0" },
     { name = "fastmcp", specifier = ">=2.0.0" },
+    { name = "filelock", specifier = ">=3.0.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.0.0" },
     { name = "pandas", specifier = ">=2.0.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },


### PR DESCRIPTION
## Summary

Adds 5 new MCP tools for working with KiCad footprint libraries, mirroring the functionality of the symbol_tools.py. Includes comprehensive caching for fast searches across 15,000+ footprints.

## New Tools

### `get_footprint_pads`
Get detailed pad information for any footprint:
- Pad number, type (smd/thru_hole), shape (circle/rect/roundrect/etc.)
- Position (x, y), angle, size
- Drill dimensions for through-hole pads

### `validate_footprint_exists`
Check if a footprint exists with smart suggestions:
- Returns description and keywords for valid footprints
- Provides similar footprint suggestions for invalid names
- Handles library-level and footprint-level validation

### `search_footprints`
Fast keyword search using cached index:
- Search across all 15,000+ footprints by name, description, or keywords
- Optional library filter
- Configurable result limit with truncation indicator

### `rebuild_footprint_index`
Build/rebuild the footprint cache:
- Parallel I/O for fast indexing (30-90s for full library)
- Progress reporting (0-100%)
- Cache stored at `~/.cache/kicad-mcp/footprint_index.json`

### `list_footprint_libraries`
List all available footprint libraries:
- Returns 155+ libraries sorted alphabetically
- Library names without `.pretty` extension

## Implementation

**Files Added:**
- `kicad_mcp/tools/footprint_tools.py` (~400 lines) - 5 MCP tools
- `kicad_mcp/utils/footprint_cache.py` (~250 lines) - Caching with parallel I/O
- `tests/unit/tools/test_footprint_tools.py` (19 tests)
- `tests/unit/utils/test_footprint_cache.py` (22 tests)

**Files Modified:**
- `kicad_mcp/server.py` - Registered footprint tools

## Testing

**41 unit tests** covering:
- Footprint ID parsing and validation
- Pad parsing (SMD, through-hole, thermal pads)
- Library listing and filtering
- Search functionality (basic, filtered, limited, empty results)
- Cache operations (build, load, save, staleness detection)
- Error handling and suggestions

**Manual testing completed** per test plan:
- All 5 tools functional
- Cache performance acceptable (< 90s rebuild, < 1s search)
- Integration across tools seamless
- Error messages clear and helpful

## Cache Details

- **Storage**: `~/.cache/kicad-mcp/footprint_index.json`
- **Size**: 15,415 footprints from 155 libraries (typical)
- **Validation**: MD5 hash-based staleness detection
- **Thread safety**: File locking with `filelock`

## Example Usage

```python
# List libraries
list_footprint_libraries()
# → 155 libraries including Resistor_SMD, Package_SO, etc.

# Search for SOIC-8 footprints
search_footprints("SOIC-8", limit=5)
# → 26 matches from Package_SO library

# Get pad details
get_footprint_pads("Resistor_SMD:R_0805_2012Metric")
# → 2 SMD pads with positions, sizes, angles

# Validate footprint
validate_footprint_exists("Package_DIP:DIP-8_W7.62mm")
# → exists=true with description
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)