### PR TITLE
feat: Add symbol library index and search tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,14 @@
 # KICAD_APP_PATH=C:\Program Files\KiCad
 # Linux:
 # KICAD_APP_PATH=/usr/share/kicad
+
+# MCP server transport protocol
+# Supported values: stdio (default), streamable-http, sse
+# MCP_TRANSPORT=stdio
+
+# KiCad version (used to build versioned directory paths)
+# KICAD_VERSION=9.0
+
+# KiCad symbol library paths (defaults are derived from KICAD_VERSION)
+# KICAD_3RD_PARTY=~/.local/share/kicad/9.0/3rdparty
+# KICAD_CONFIG_DIR=~/.config/kicad/9.0

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,11 @@ logs/
 # MCP specific
 ~/.kicad_mcp/drc_history/
 
+# Symbol database files (auto-generated, do not commit)
+kicad_mcp/utils/symbol_db/*.db
+kicad_mcp/utils/symbol_db/*.db-shm
+kicad_mcp/utils/symbol_db/*.db-wal
+
 # UV and modern Python tooling
 uv.lock
 .uv-cache/

--- a/kicad_mcp/config.py
+++ b/kicad_mcp/config.py
@@ -7,6 +7,7 @@ All settings are determined at import time based on the operating system.
 
 Module Variables:
     system (str): Operating system name from platform.system()
+    KICAD_VERSION (str): KiCad version string used to construct versioned paths
     KICAD_USER_DIR (str): User's KiCad documents directory
     KICAD_APP_PATH (str): KiCad application installation path
     ADDITIONAL_SEARCH_PATHS (List[str]): Additional project search locations
@@ -20,6 +21,7 @@ Module Variables:
     TIMEOUT_CONSTANTS (Dict[str, float]): Operation timeout values in seconds
     PROGRESS_CONSTANTS (Dict[str, int]): Progress reporting percentage values
     DISPLAY_CONSTANTS (Dict[str, int]): UI display configuration values
+    LibraryPathConfig: Configuration class for symbol library paths and settings
 
 Platform Support:
     - macOS (Darwin): Full support with application bundle paths
@@ -197,3 +199,97 @@ PROGRESS_CONSTANTS = {
 DISPLAY_CONSTANTS = {
     "bom_preview_limit": 20,  # Maximum number of BOM items to show in preview
 }
+
+# KiCad version string — fallback used when KICAD_VERSION env var is not set
+KICAD_VERSION = "9.0"
+
+class LibraryPathConfig:
+    """
+    KiCad symbol library path configuration.
+
+    Reads KICAD_VERSION and each path from the corresponding environment
+    variable; if a variable is absent the built-in default is used. The
+    resolved values are collected into ``self._env_vars`` so they can be
+    injected into subprocess environments that expand ``${VAR}`` URI
+    references.
+    """
+
+    @staticmethod
+    def _default_symbol_dir(kicad_app_path: str) -> str:
+        """Return the platform-specific default KiCad system symbols directory."""
+        if system == "Darwin":
+            return os.path.join(kicad_app_path, "Contents", "SharedSupport", "symbols")
+        elif system == "Windows":
+            return os.path.join(kicad_app_path, "share", "kicad", "symbols")
+        else:
+            return os.path.join(kicad_app_path, "symbols")
+
+    @staticmethod
+    def _default_config_dir(kicad_version: str) -> str:
+        """Return the platform-specific default KiCad configuration directory."""
+        if system == "Darwin":
+            return os.path.expanduser(f"~/Library/Preferences/kicad/{kicad_version}")
+        elif system == "Windows":
+            appdata = os.environ.get("APPDATA", os.path.expanduser("~"))
+            return os.path.join(appdata, "kicad", kicad_version)
+        else:
+            return os.path.expanduser(f"~/.config/kicad/{kicad_version}")
+
+    @staticmethod
+    def _default_3rd_party(kicad_version: str) -> str:
+        """Return the platform-specific default KiCad 3rd-party packages directory."""
+        if system == "Darwin":
+            return os.path.expanduser(f"~/Library/Application Support/kicad/{kicad_version}/3rdparty")
+        elif system == "Windows":
+            appdata = os.environ.get("APPDATA", os.path.expanduser("~"))
+            return os.path.join(appdata, "kicad", kicad_version, "3rdparty")
+        else:
+            return os.path.expanduser(f"~/.local/share/kicad/{kicad_version}/3rdparty")
+
+    @staticmethod
+    def _default_template_dir(kicad_app_path: str, kicad_version: str) -> str:
+        """Return the platform-specific default KiCad templates directory."""
+        if system == "Darwin":
+            return os.path.join(kicad_app_path, "Contents", "SharedSupport", "template")
+        elif system == "Windows":
+            return os.path.join(kicad_app_path, "share", "kicad", "template")
+        else:
+            return os.path.join(kicad_app_path, "template")
+
+    def __init__(self):
+        kicad_version = os.environ.get("KICAD_VERSION") or KICAD_VERSION
+        _ver_tag = kicad_version.split(".")[0]
+        kicad_app_path = os.environ.get("KICAD_APP_PATH") or KICAD_APP_PATH
+
+        self._kicad_config_dir = (
+            os.environ.get("KICAD_CONFIG_DIR")
+            or self._default_config_dir(kicad_version)
+        )
+        self._kicad_symbol_dir = (
+            os.environ.get("KICAD_SYMBOL_DIR")
+            or self._default_symbol_dir(kicad_app_path)
+        )
+        self._kicad_3rd_party = (
+            os.environ.get("KICAD_3RD_PARTY")
+            or self._default_3rd_party(kicad_version)
+        )
+        self._kicad_template_dir = (
+            os.environ.get("KICAD_TEMPLATE_DIR")
+            or self._default_template_dir(kicad_app_path, kicad_version)
+        )
+
+        # Env vars to inject into subprocesses that expand ${VAR} placeholders in library URIs
+        self._env_vars = {
+            f"KICAD{_ver_tag}_SYMBOL_DIR": self._kicad_symbol_dir,
+            f"KICAD{_ver_tag}_3RD_PARTY": self._kicad_3rd_party,
+            f"KICAD{_ver_tag}_TEMPLATE_DIR": self._kicad_template_dir
+        }
+
+    @property
+    def symbol_table_file(self) -> str:
+        """Path to the sym-lib-table file."""
+        return self._kicad_config_dir + "/sym-lib-table"
+
+    def get_env_vars(self):
+        """Get the complete environment variables dictionary."""
+        return self._env_vars.copy()

--- a/kicad_mcp/server.py
+++ b/kicad_mcp/server.py
@@ -26,6 +26,7 @@ from kicad_mcp.tools.drc_tools import register_drc_tools
 from kicad_mcp.tools.bom_tools import register_bom_tools
 from kicad_mcp.tools.netlist_tools import register_netlist_tools
 from kicad_mcp.tools.pattern_tools import register_pattern_tools
+from kicad_mcp.tools.symbol_tools import register_symbol_tools
 
 # Import prompt handlers
 from kicad_mcp.prompts.templates import register_prompts
@@ -153,6 +154,7 @@ def create_server() -> FastMCP:
     register_bom_tools(mcp)
     register_netlist_tools(mcp)
     register_pattern_tools(mcp)
+    register_symbol_tools(mcp)
     
     # Register prompts
     logging.info(f"Registering prompts...")
@@ -216,9 +218,14 @@ def main() -> None:
     logging.info("Starting KiCad MCP server...")
     
     server = create_server()
+
+    # Read transport from environment variable; default to 'stdio'
+    # Supported values: 'stdio', 'streamable-http', 'sse'
+    transport = os.environ.get('MCP_TRANSPORT', 'stdio')
+    logging.info(f"Using transport: {transport}")
     
     try:
-        server.run()  # FastMCP manages its own event loop
+        server.run(transport=transport)  # FastMCP manages its own event loop
     except KeyboardInterrupt:
         logging.info("Server interrupted by user")
     except Exception as e:

--- a/kicad_mcp/tools/symbol_tools.py
+++ b/kicad_mcp/tools/symbol_tools.py
@@ -1,0 +1,311 @@
+"""
+Symbol library tools for KiCad MCP server.
+
+Provides tools to index, search, and look up KiCad symbol libraries
+using a SQLite-backed full-text search index.
+"""
+import logging
+import threading
+from dataclasses import dataclass, field
+from typing import Any
+
+from fastmcp import FastMCP
+from mcp.server.fastmcp import Context
+
+from kicad_mcp.config import LibraryPathConfig
+from kicad_mcp.utils.symbol_index_reader import SymbolIndexReader
+from kicad_mcp.utils.symbol_index_manager import SymbolIndexManager
+
+log = logging.getLogger(__name__)
+
+# Module-level singleton so the DB connection is reused across tool calls.
+_index_manager: SymbolIndexManager | None = None
+
+
+def _get_index_manager() -> SymbolIndexManager:
+    global _index_manager
+    if _index_manager is None:
+        config = LibraryPathConfig()
+        library_reader = SymbolIndexReader(config)
+        _index_manager = SymbolIndexManager(library_reader)
+    return _index_manager
+
+
+# ---------------------------------------------------------------------------
+# Background sync state (thread-safe via lock)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _SyncState:
+    running: bool = False
+    current: int = 0
+    total: int = 0
+    current_library: str = ''
+    last_result: dict | None = None
+    error: str | None = None
+
+_sync_state = _SyncState()
+_sync_lock = threading.Lock()
+
+
+def _run_sync_in_background(force: bool) -> None:
+    """Target function executed in the background sync thread."""
+    def _progress(current: int, total: int, library_name: str) -> None:
+        with _sync_lock:
+            _sync_state.current = current
+            _sync_state.total = total
+            _sync_state.current_library = library_name
+
+    try:
+        mgr = _get_index_manager()
+        stats = mgr.sync(force=force, progress_callback=_progress)
+        result = {
+            "success": True,
+            "added": stats.added,
+            "updated": stats.updated,
+            "removed": stats.removed,
+            "skipped": stats.skipped,
+            "failed": stats.failed,
+            "total_symbols": stats.total_symbols,
+            "elapsed_seconds": round(stats.elapsed_seconds, 2),
+        }
+        with _sync_lock:
+            _sync_state.last_result = result
+            _sync_state.error = None
+    except Exception as e:
+        log.error(f"Background symbol index sync failed: {e}", exc_info=True)
+        with _sync_lock:
+            _sync_state.last_result = None
+            _sync_state.error = str(e)
+    finally:
+        with _sync_lock:
+            _sync_state.running = False
+            _sync_state.current_library = ''
+
+
+def register_symbol_tools(mcp: FastMCP) -> None:
+    """Register symbol library tools with the MCP server."""
+
+    @mcp.tool()
+    async def sync_symbol_index(force: bool = False, ctx: Context | None = None) -> dict[str, Any]:
+        """
+        Start syncing the symbol index database with the current KiCad symbol libraries.
+
+        This tool returns immediately — the actual sync runs in a background thread
+        to avoid tool call timeouts. The first sync can take several minutes because
+        it parses all .kicad_sym files. Subsequent calls are incremental.
+
+        After calling this tool, use get_symbol_sync_status to monitor progress and
+        check when the sync completes. Do NOT call sync_symbol_index again while a
+        sync is already running.
+
+        Args:
+            force: If True, reparse every library regardless of whether it changed. This can take
+                   a long time to complete. Use force=True only when the database is messed up.
+        """
+        with _sync_lock:
+            if _sync_state.running:
+                return {
+                    "status": "already_running",
+                    "message": "A sync is already in progress. Use get_symbol_sync_status to check progress.",
+                    "current": _sync_state.current,
+                    "total": _sync_state.total,
+                    "current_library": _sync_state.current_library,
+                }
+            # Mark as running and reset state before spawning the thread
+            _sync_state.running = True
+            _sync_state.current = 0
+            _sync_state.total = 0
+            _sync_state.current_library = ''
+            _sync_state.error = None
+
+        if ctx:
+            await ctx.info("Starting symbol index sync in background thread...")
+
+        t = threading.Thread(target=_run_sync_in_background, args=(force,), daemon=True)
+        t.start()
+        log.info("Background symbol sync thread started.")
+        return {
+            "status": "started",
+            "message": "Symbol index sync started in the background. "
+                       "Call get_symbol_sync_status to monitor progress.",
+        }
+
+    @mcp.tool()
+    async def get_symbol_sync_status(ctx: Context | None = None) -> dict[str, Any]:
+        """
+        Return the current status of the background symbol index sync.
+
+        Call this after sync_symbol_index to monitor progress. Poll every few
+        seconds until 'running' is False. When running is False and last_result
+        is present, the sync completed successfully. When running is False and
+        error is present, the sync failed.
+        """
+        with _sync_lock:
+            state = {
+                "running": _sync_state.running,
+                "current": _sync_state.current,
+                "total": _sync_state.total,
+                "current_library": _sync_state.current_library,
+                "last_result": _sync_state.last_result,
+                "error": _sync_state.error,
+            }
+        return state
+
+    @mcp.tool()
+    async def search_symbols(
+        query: str,
+        limit: int = 50,
+        ctx: Context | None = None,
+    ) -> dict[str, Any]:
+        """
+        Full-text search across all indexed KiCad symbols.
+
+        Searches symbol name, description, and keywords. Results are ordered
+        by relevance. Run sync_symbol_index first if the index is empty.
+
+        Args:
+            query: Search string (e.g. "resistor", "NPN transistor", "STM32").
+            limit: Maximum number of results to return (default 50).
+        """
+        try:
+            mgr = _get_index_manager()
+            results = mgr.search_symbols(query, limit=limit)
+            return {
+                "success": True,
+                "query": query,
+                "count": len(results),
+                "symbols": [
+                    {
+                        "library": s.library_name,
+                        "name": s.symbol_name,
+                        "description": s.description,
+                        "keywords": s.keywords,
+                        "pin_count": s.pin_count,
+                    }
+                    for s in results
+                ],
+            }
+        except Exception as e:
+            log.error(f"Symbol search failed: {e}", exc_info=True)
+            return {"success": False, "error": str(e)}
+
+    @mcp.tool()
+    async def get_symbol(
+        library_name: str,
+        symbol_name: str,
+        ctx: Context | None = None,
+    ) -> dict[str, Any]:
+        """
+        Look up a single KiCad symbol by library and symbol name.
+
+        Args:
+            library_name: The library name as it appears in sym-lib-table (e.g. "Device").
+            symbol_name:  The symbol name within the library (e.g. "R").
+        """
+        try:
+            mgr = _get_index_manager()
+            symbol = mgr.get_symbol(library_name, symbol_name)
+            if symbol is None:
+                return {
+                    "success": False,
+                    "error": f"Symbol '{library_name}:{symbol_name}' not found in index.",
+                }
+            return {
+                "success": True,
+                "library": symbol.library_name,
+                "name": symbol.symbol_name,
+                "description": symbol.description,
+                "keywords": symbol.keywords,
+                "pin_count": symbol.pin_count,
+            }
+        except Exception as e:
+            log.error(f"get_symbol failed: {e}", exc_info=True)
+            return {"success": False, "error": str(e)}
+
+    @mcp.tool()
+    async def list_symbol_libraries(ctx: Context | None = None) -> dict[str, Any]:
+        """
+        List all KiCad symbol libraries currently in the index.
+
+        Returns library names, file paths, symbol counts, and KiCad version.
+        Run sync_symbol_index first if the list is empty.
+        """
+        try:
+            mgr = _get_index_manager()
+            libraries = mgr.get_all_libraries()
+            return {
+                "success": True,
+                "count": len(libraries),
+                "libraries": [
+                    {
+                        "name": lib.library_name,
+                        "path": lib.file_path,
+                        "symbol_count": lib.symbol_count,
+                        "kicad_version": lib.kicad_version,
+                    }
+                    for lib in libraries
+                ],
+            }
+        except Exception as e:
+            log.error(f"list_symbol_libraries failed: {e}", exc_info=True)
+            return {"success": False, "error": str(e)}
+
+    @mcp.tool()
+    async def get_library_symbols(
+        library_name: str,
+        ctx: Context | None = None,
+    ) -> dict[str, Any]:
+        """
+        Return all symbols in a specific KiCad symbol library.
+
+        Args:
+            library_name: The library name as it appears in sym-lib-table (e.g. "Device").
+        """
+        try:
+            mgr = _get_index_manager()
+            symbols = mgr.get_library_symbols(library_name)
+            if not symbols:
+                return {
+                    "success": False,
+                    "error": f"Library '{library_name}' not found or has no indexed symbols.",
+                }
+            return {
+                "success": True,
+                "library": library_name,
+                "count": len(symbols),
+                "symbols": [
+                    {
+                        "name": s.symbol_name,
+                        "description": s.description,
+                        "keywords": s.keywords,
+                        "pin_count": s.pin_count,
+                    }
+                    for s in symbols
+                ],
+            }
+        except Exception as e:
+            log.error(f"get_library_symbols failed: {e}", exc_info=True)
+            return {"success": False, "error": str(e)}
+
+    @mcp.tool()
+    async def get_symbol_index_stats(ctx: Context | None = None) -> dict[str, Any]:
+        """
+        Return summary statistics about the symbol index database.
+
+        Shows how many libraries and symbols are indexed, when the last sync
+        ran, and where the database file is located.
+        """
+        try:
+            mgr = _get_index_manager()
+            stats = mgr.get_statistics()
+            return {
+                "success": True,
+                "library_count": stats.library_count,
+                "symbol_count": stats.symbol_count,
+                "last_sync": stats.last_sync,
+                "db_path": stats.db_path,
+            }
+        except Exception as e:
+            log.error(f"get_symbol_index_stats failed: {e}", exc_info=True)
+            return {"success": False, "error": str(e)}

--- a/kicad_mcp/tools/symbol_tools.py
+++ b/kicad_mcp/tools/symbol_tools.py
@@ -167,6 +167,15 @@ def register_symbol_tools(mcp: FastMCP) -> None:
         Args:
             query: Search string (e.g. "resistor", "NPN transistor", "STM32").
             limit: Maximum number of results to return (default 50).
+
+        Returns:
+            A dict with a ``symbols`` list. Each entry has:
+            - ``library_name``: the exact value to pass as ``library_name`` to
+              ``add_symbol_to_schematic``, ``get_symbol``, or
+              ``get_library_symbols``.  For KiCad 10 symdir-style libraries
+              this is ``"TableName/FileBaseName"`` (e.g. ``"Device/R_Small"``),
+              not just the table name (e.g. not ``"Device"``).
+            - ``name``: the exact value to pass as ``symbol_name``.
         """
         try:
             mgr = _get_index_manager()
@@ -177,7 +186,7 @@ def register_symbol_tools(mcp: FastMCP) -> None:
                 "count": len(results),
                 "symbols": [
                     {
-                        "library": s.library_name,
+                        "library_name": s.library_name,
                         "name": s.symbol_name,
                         "description": s.description,
                         "keywords": s.keywords,
@@ -200,7 +209,10 @@ def register_symbol_tools(mcp: FastMCP) -> None:
         Look up a single KiCad symbol by library and symbol name.
 
         Args:
-            library_name: The library name as it appears in sym-lib-table (e.g. "Device").
+            library_name: The library name returned by ``search_symbols`` in the
+                ``library_name`` field.  For KiCad 10 symdir-style libraries
+                this is ``"TableName/FileBaseName"`` (e.g. ``"Device/R_Small"``)
+                not just the table name (e.g. not ``"Device"``).
             symbol_name:  The symbol name within the library (e.g. "R").
         """
         try:
@@ -213,7 +225,7 @@ def register_symbol_tools(mcp: FastMCP) -> None:
                 }
             return {
                 "success": True,
-                "library": symbol.library_name,
+                "library_name": symbol.library_name,
                 "name": symbol.symbol_name,
                 "description": symbol.description,
                 "keywords": symbol.keywords,
@@ -260,7 +272,11 @@ def register_symbol_tools(mcp: FastMCP) -> None:
         Return all symbols in a specific KiCad symbol library.
 
         Args:
-            library_name: The library name as it appears in sym-lib-table (e.g. "Device").
+            library_name: The library name returned by ``search_symbols`` or
+                ``list_symbol_libraries`` in the ``library_name`` field.  For
+                KiCad 10 symdir-style libraries this is
+                ``"TableName/FileBaseName"`` (e.g. ``"Device/R_Small"``), not
+                just the table name (e.g. not ``"Device"``).
         """
         try:
             mgr = _get_index_manager()
@@ -272,7 +288,7 @@ def register_symbol_tools(mcp: FastMCP) -> None:
                 }
             return {
                 "success": True,
-                "library": library_name,
+                "library_name": library_name,
                 "count": len(symbols),
                 "symbols": [
                     {

--- a/kicad_mcp/utils/symbol_database.py
+++ b/kicad_mcp/utils/symbol_database.py
@@ -1,0 +1,500 @@
+"""
+SQLite-backed symbol index database for KiCad symbol libraries.
+
+Uses SQLAlchemy 2.x for all database operations.
+
+Tables
+------
+libraries  -- one row per .kicad_sym file (id, path, mtime, size, ...)
+symbols    -- one row per symbol (library_name, symbol_name, ...)
+symbols_fts -- FTS5 virtual table mirroring symbols for full-text search
+
+Note on FTS5
+------------
+SQLAlchemy has no native support for SQLite FTS5 virtual tables or their
+associated triggers. The FTS5 DDL and MATCH queries use ``text()`` executed
+directly against the connection, while all standard CRUD goes through the
+ORM session.
+"""
+
+import os
+import re
+import time
+import logging
+from dataclasses import dataclass
+
+from sqlalchemy import (
+    Column, Integer, Float, String, ForeignKey,
+    Index, create_engine, text, event, func, select, insert
+)
+from sqlalchemy.orm import DeclarativeBase, sessionmaker
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public dataclasses  (the external API — never expose ORM rows directly)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class LibraryRecord:
+    id: int
+    library_name: str
+    file_path: str
+    file_size: int
+    mtime: float
+    checksum: str
+    symbol_count: int
+    last_indexed: float
+    kicad_version: str
+
+
+@dataclass
+class SymbolRecord:
+    library_name: str
+    symbol_name: str
+    library_id: int
+    description: str
+    keywords: str
+    pin_count: int
+    file_index: int
+
+
+@dataclass
+class DbStats:
+    library_count: int
+    symbol_count: int
+    last_sync: float        # Unix timestamp; 0.0 if never synced
+    db_path: str
+
+
+# ---------------------------------------------------------------------------
+# ORM models  (internal — prefixed with _ to signal non-public)
+# ---------------------------------------------------------------------------
+
+class _Base(DeclarativeBase):
+    pass
+
+
+class _LibraryRow(_Base):
+    __tablename__ = 'libraries'
+
+    id            = Column(Integer, primary_key=True, autoincrement=True)
+    library_name  = Column(String,  nullable=False)
+    file_path     = Column(String,  nullable=False, unique=True)
+    file_size     = Column(Integer, nullable=False, default=0)
+    mtime         = Column(Float,   nullable=False, default=0.0)
+    checksum      = Column(String,  nullable=False, default='')
+    symbol_count  = Column(Integer, nullable=False, default=0)
+    last_indexed  = Column(Float,   nullable=False, default=0.0)
+    kicad_version = Column(String,  nullable=False, default='')
+
+
+class _SymbolRow(_Base):
+    __tablename__ = 'symbols'
+
+    library_name = Column(String,  nullable=False, primary_key=True)
+    symbol_name  = Column(String,  nullable=False, primary_key=True)
+    library_id   = Column(Integer, ForeignKey('libraries.id', ondelete='CASCADE'),
+                          nullable=False)
+    description  = Column(String,  nullable=False, default='')
+    keywords     = Column(String,  nullable=False, default='')
+    pin_count    = Column(Integer, nullable=False, default=0)
+    file_index   = Column(Integer, nullable=False, default=0)
+
+    __table_args__ = (
+        Index('idx_sym_library_id', 'library_id'),
+        Index('idx_sym_name', 'symbol_name'),
+    )
+
+
+# FTS5 virtual table + trigger DDL — executed once at schema setup time.
+_DDL_FTS = """\
+CREATE VIRTUAL TABLE IF NOT EXISTS symbols_fts USING fts5(
+    library_name,
+    symbol_name,
+    description,
+    keywords,
+    content='symbols',
+    content_rowid='rowid',
+    tokenize='unicode61'
+);
+
+CREATE TRIGGER IF NOT EXISTS symbols_ai AFTER INSERT ON symbols BEGIN
+    INSERT INTO symbols_fts(rowid, library_name, symbol_name, description, keywords)
+    VALUES (new.rowid, new.library_name, new.symbol_name, new.description, new.keywords);
+END;
+
+CREATE TRIGGER IF NOT EXISTS symbols_ad AFTER DELETE ON symbols BEGIN
+    INSERT INTO symbols_fts(symbols_fts, rowid, library_name, symbol_name, description, keywords)
+    VALUES ('delete', old.rowid, old.library_name, old.symbol_name, old.description, old.keywords);
+END;
+
+"""
+
+
+# ---------------------------------------------------------------------------
+# SymbolDatabase
+# ---------------------------------------------------------------------------
+
+class SymbolDatabase:
+    """SQLAlchemy-backed store for KiCad symbol library index data."""
+
+    def __init__(self, db_path: str):
+        """
+        Open (or create) the database at db_path.
+        The parent directory is created automatically if needed.
+        """
+        os.makedirs(os.path.dirname(os.path.abspath(db_path)), exist_ok=True)
+        self._db_path = db_path
+
+        self._engine = create_engine(
+            f'sqlite:///{db_path}',
+            connect_args={'check_same_thread': False},
+        )
+
+        # Enable WAL mode and foreign keys on every new connection.
+        @event.listens_for(self._engine, 'connect')
+        def _set_pragmas(conn, _record):
+            conn.execute('PRAGMA journal_mode = WAL')
+            conn.execute('PRAGMA foreign_keys = ON')
+
+        self._Session = sessionmaker(bind=self._engine)
+        self._apply_schema()
+
+    # ------------------------------------------------------------------
+    # Schema
+    # ------------------------------------------------------------------
+
+    def _apply_schema(self) -> None:
+        """Create ORM tables and FTS5 virtual table / triggers."""
+        _Base.metadata.create_all(self._engine)
+        with self._engine.connect() as conn:
+            try:
+                for statement in _DDL_FTS.split(';\n\n'):
+                    stmt = statement.strip()
+                    if stmt:
+                        conn.execute(text(stmt))
+                conn.commit()
+            except Exception as exc:
+                log.warning(
+                    f"FTS5 not available in this SQLite build — "
+                    f"full-text search disabled. ({exc})"
+                )
+
+    # ------------------------------------------------------------------
+    # Public API — state query (used by SymbolIndexManager for sync)
+    # ------------------------------------------------------------------
+
+    def get_library_states(self) -> dict[str, tuple[int, float, int, str]]:
+        """
+        Return a snapshot of all indexed libraries as
+        ``{file_path: (id, mtime, file_size, checksum)}``.
+        """
+        with self._Session() as session:
+            rows = session.execute(
+                select(
+                    _LibraryRow.id,
+                    _LibraryRow.file_path,
+                    _LibraryRow.mtime,
+                    _LibraryRow.file_size,
+                    _LibraryRow.checksum,
+                )
+            ).all()
+        return {
+            row.file_path: (row.id, row.mtime, row.file_size, row.checksum)
+            for row in rows
+        }
+
+    # ------------------------------------------------------------------
+    # Public API — write (used by SymbolIndexManager)
+    # ------------------------------------------------------------------
+
+    def save_library(
+        self,
+        library_name: str,
+        file_path: str,
+        mtime: float,
+        file_size: int,
+        kicad_version: str,
+        symbols: list[SymbolRecord],
+        checksum: str = '',
+    ) -> int:
+        """
+        Insert or fully replace a library and its symbols in one transaction.
+        Returns the number of symbols stored.
+        """
+        now = time.time()
+        with self._Session() as session:
+            # Always delete any existing row for this path (symbols are removed
+            # via ON DELETE CASCADE) and insert a fresh record.  This avoids
+            # any risk of stale data from a partial or in-place update.
+            session.execute(
+                _LibraryRow.__table__.delete().where(_LibraryRow.file_path == file_path)
+            )
+
+            lib_row = _LibraryRow(
+                library_name=library_name,
+                file_path=file_path,
+                file_size=file_size,
+                mtime=mtime,
+                checksum=checksum,
+                symbol_count=len(symbols),
+                last_indexed=now,
+                kicad_version=kicad_version,
+            )
+            session.add(lib_row)
+            session.flush()   # assigns lib_row.id
+            lib_id: int = lib_row.id
+
+            if symbols:
+                session.execute(
+                    insert(_SymbolRow),
+                    [
+                        {
+                            'library_name': library_name,
+                            'symbol_name':  sym.symbol_name,
+                            'library_id':   lib_id,
+                            'description':  sym.description,
+                            'keywords':     sym.keywords,
+                            'pin_count':    sym.pin_count,
+                            'file_index':   sym.file_index,
+                        }
+                        for sym in symbols
+                    ],
+                )
+            session.commit()
+
+        return len(symbols)
+
+    def touch_library(
+        self,
+        lib_id: int,
+        mtime: float,
+        file_size: int,
+        checksum: str,
+    ) -> None:
+        """
+        Update only the file metadata (mtime, size, checksum) for a library
+        whose content has not changed — avoids a full reparse.
+        """
+        with self._Session() as session:
+            session.execute(
+                _LibraryRow.__table__.update()
+                .where(_LibraryRow.id == lib_id)
+                .values(mtime=mtime, file_size=file_size, checksum=checksum)
+            )
+            session.commit()
+
+    def delete_library(self, lib_id: int) -> None:
+        """Delete a library row (symbols removed via ON DELETE CASCADE)."""
+        with self._Session() as session:
+            session.execute(
+                _LibraryRow.__table__.delete().where(_LibraryRow.id == lib_id)
+            )
+            session.commit()
+
+    # ------------------------------------------------------------------
+    # Public API — search
+    # ------------------------------------------------------------------
+
+    def search(self, query: str, limit: int = 50) -> list[SymbolRecord]:
+        """
+        Full-text search across symbol_name, description, and keywords.
+        Returns results ordered by FTS5 rank (best match first).
+        Falls back to LIKE search if FTS5 is unavailable.
+        """
+        safe_query = self._fts_escape(query)
+        sql = text(
+            """
+            SELECT s.library_name, s.symbol_name, s.library_id,
+                   s.description, s.keywords, s.pin_count, s.file_index
+            FROM symbols_fts f
+            JOIN symbols s ON s.rowid = f.rowid
+            WHERE symbols_fts MATCH :q
+            ORDER BY rank
+            LIMIT :lim
+            """
+        )
+        try:
+            with self._engine.connect() as conn:
+                rows = conn.execute(sql, {'q': safe_query, 'lim': limit}).all()
+            return [self._row_to_symbol(r) for r in rows]
+        except Exception:
+            log.debug("FTS5 unavailable, falling back to LIKE search")
+            return self.search_by_name(query, limit=limit)
+
+    def search_by_name(
+        self,
+        name: str,
+        exact: bool = False,
+        limit: int = 50,
+    ) -> list[SymbolRecord]:
+        """
+        Search symbols by name.
+        exact=True  — case-insensitive exact match.
+        exact=False — case-insensitive substring match.
+        """
+        with self._Session() as session:
+            q = select(_SymbolRow)
+            if exact:
+                q = q.where(func.lower(_SymbolRow.symbol_name) == name.lower())
+            else:
+                q = q.where(
+                    _SymbolRow.symbol_name.ilike(
+                        f'%{self._like_escape(name)}%', escape='\\'
+                    )
+                )
+            rows = session.execute(q.limit(limit)).scalars().all()
+        return [self._orm_to_symbol(r) for r in rows]
+
+    # ------------------------------------------------------------------
+    # Public API — lookup
+    # ------------------------------------------------------------------
+
+    def get_symbol(
+        self, library_name: str, symbol_name: str
+    ) -> SymbolRecord | None:
+        """Look up a single symbol by (library_name, symbol_name)."""
+        with self._Session() as session:
+            row = session.execute(
+                select(_SymbolRow).where(
+                    _SymbolRow.library_name == library_name,
+                    _SymbolRow.symbol_name == symbol_name,
+                )
+            ).scalar_one_or_none()
+        return self._orm_to_symbol(row) if row else None
+
+    def get_library_symbols(self, library_name: str) -> list[SymbolRecord]:
+        """Return all symbols in a library, ordered by their position in the file."""
+        with self._Session() as session:
+            rows = session.execute(
+                select(_SymbolRow)
+                .where(_SymbolRow.library_name == library_name)
+                .order_by(_SymbolRow.file_index)
+            ).scalars().all()
+        return [self._orm_to_symbol(r) for r in rows]
+
+    def get_all_symbols(self) -> list[SymbolRecord]:
+        """Return every indexed symbol, ordered by library then position."""
+        with self._Session() as session:
+            rows = session.execute(
+                select(_SymbolRow)
+                .order_by(_SymbolRow.library_name, _SymbolRow.file_index)
+            ).scalars().all()
+        return [self._orm_to_symbol(r) for r in rows]
+
+    def get_all_libraries(self) -> list[LibraryRecord]:
+        """Return all indexed library records, ordered alphabetically."""
+        with self._Session() as session:
+            rows = session.execute(
+                select(_LibraryRow).order_by(_LibraryRow.library_name)
+            ).scalars().all()
+        return [self._orm_to_library(r) for r in rows]
+
+    def get_library_by_name(self, name: str) -> LibraryRecord | None:
+        """Look up a single library record by library_name."""
+        with self._Session() as session:
+            row = session.execute(
+                select(_LibraryRow).where(_LibraryRow.library_name == name)
+            ).scalar_one_or_none()
+        return self._orm_to_library(row) if row else None
+
+    def get_symbol_file_index(
+        self, library_name: str, symbol_name: str
+    ) -> int | None:
+        """Return the 0-based file_index of a symbol, or None if not found."""
+        with self._Session() as session:
+            row = session.execute(
+                select(_SymbolRow.file_index).where(
+                    _SymbolRow.library_name == library_name,
+                    _SymbolRow.symbol_name == symbol_name,
+                )
+            ).scalar_one_or_none()
+        return int(row) if row is not None else None
+
+    def get_stats(self) -> DbStats:
+        """Return summary statistics about the database."""
+        with self._Session() as session:
+            lib_count: int = session.execute(
+                select(func.count()).select_from(_LibraryRow)
+            ).scalar_one()
+            sym_count: int = session.execute(
+                select(func.count()).select_from(_SymbolRow)
+            ).scalar_one()
+            last_sync = session.execute(
+                select(func.max(_LibraryRow.last_indexed))
+            ).scalar_one()
+        return DbStats(
+            library_count=lib_count,
+            symbol_count=sym_count,
+            last_sync=float(last_sync) if last_sync else 0.0,
+            db_path=self._db_path,
+        )
+
+    def close(self) -> None:
+        """Dispose the engine (closes all pooled connections)."""
+        self._engine.dispose()
+
+    # ------------------------------------------------------------------
+    # Internal helpers — query sanitization
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _fts_escape(query: str) -> str:
+        """
+        Convert a plain user query string into a safe FTS5 MATCH expression.
+        Each whitespace-separated token is double-quoted to prevent FTS5
+        syntax errors on inputs like 'C++' or '24V'.
+        """
+        tokens = re.split(r'\s+', query.strip())
+        escaped = ' '.join(f'"{t}"' for t in tokens if t)
+        return escaped if escaped else '""'
+
+    @staticmethod
+    def _like_escape(s: str) -> str:
+        """Escape LIKE special characters in a user-supplied substring."""
+        return s.replace('\\', '\\\\').replace('%', '\\%').replace('_', '\\_')
+
+    # ------------------------------------------------------------------
+    # Internal helpers — ORM row → public dataclass
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _orm_to_symbol(row: _SymbolRow) -> SymbolRecord:
+        return SymbolRecord(
+            library_name=row.library_name,
+            symbol_name=row.symbol_name,
+            library_id=row.library_id,
+            description=row.description,
+            keywords=row.keywords,
+            pin_count=row.pin_count,
+            file_index=row.file_index,
+        )
+
+    @staticmethod
+    def _orm_to_library(row: _LibraryRow) -> LibraryRecord:
+        return LibraryRecord(
+            id=row.id,
+            library_name=row.library_name,
+            file_path=row.file_path,
+            file_size=row.file_size,
+            mtime=row.mtime,
+            checksum=row.checksum,
+            symbol_count=row.symbol_count,
+            last_indexed=row.last_indexed,
+            kicad_version=row.kicad_version,
+        )
+
+    # FTS search returns raw DB rows (not ORM objects) — handle separately.
+    @staticmethod
+    def _row_to_symbol(row) -> SymbolRecord:
+        return SymbolRecord(
+            library_name=row.library_name,
+            symbol_name=row.symbol_name,
+            library_id=row.library_id,
+            description=row.description,
+            keywords=row.keywords,
+            pin_count=row.pin_count,
+            file_index=row.file_index,
+        )

--- a/kicad_mcp/utils/symbol_index_manager.py
+++ b/kicad_mcp/utils/symbol_index_manager.py
@@ -1,0 +1,490 @@
+"""
+Symbol Index Manager
+
+Bridges SymbolIndexReader (reads sym-lib-table) and SymbolDatabase
+(SQLite index). Provides a single high-level API for syncing, searching,
+and looking up KiCad symbols.
+
+Parsing responsibility:
+    This module owns all .kicad_sym file parsing via the skip library.
+    SymbolDatabase is a pure storage layer; it receives already-parsed
+    SymbolRecord lists and knows nothing about skip or KiCad file formats.
+
+Database location:
+    <this file's directory>/symbol_db/kicad_symbols.db
+"""
+
+import os
+import hashlib
+import time
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+import skip.sexp.sourcefile
+import skip.collection
+
+from kicad_mcp.utils.symbol_index_reader import SymbolIndexReader
+from kicad_mcp.utils.symbol_database import (
+    SymbolDatabase,
+    SymbolRecord,
+    LibraryRecord,
+    DbStats,
+)
+
+log = logging.getLogger(__name__)
+
+_DEFAULT_DB_PATH = Path(__file__).parent / 'symbol_db' / 'kicad_symbols.db'
+
+
+# ---------------------------------------------------------------------------
+# SyncStats
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SyncStats:
+    added: int
+    updated: int
+    removed: int
+    skipped: int
+    failed: int
+    total_symbols: int
+    elapsed_seconds: float
+
+
+# ---------------------------------------------------------------------------
+# Optional diagnostic dependencies
+# ---------------------------------------------------------------------------
+
+try:
+    import objgraph as _objgraph          # type: ignore
+except ImportError:
+    _objgraph = None
+
+try:
+    from pympler import asizeof as _asizeof  # type: ignore
+except ImportError:
+    _asizeof = None
+
+
+def _rss_mb() -> float:
+    """Return current process RSS in MB (Linux only)."""
+    try:
+        with open('/proc/self/status') as f:
+            for line in f:
+                if line.startswith('VmRSS:'):
+                    return int(line.split()[1]) / 1024.0
+    except OSError:
+        pass
+    return 0.0
+
+
+def _parsed_value_count() -> int | None:
+    if _objgraph is None:
+        return None
+    return _objgraph.count('ParsedValue')
+
+
+# ---------------------------------------------------------------------------
+# SymbolIndexManager
+# ---------------------------------------------------------------------------
+
+class SymbolIndexManager:
+    """
+    High-level API for indexing and searching KiCad symbols.
+
+    On first use, call sync() to parse all libraries and populate the DB.
+    Subsequent calls to sync() are incremental — only changed or new files
+    are reparsed.
+
+    Example
+    -------
+        mgr = SymbolIndexReader()
+        idx = SymbolIndexManager(mgr)
+        stats = idx.sync()
+        results = idx.search_symbols('resistor')
+    """
+
+    def __init__(
+        self,
+        library_manager: SymbolIndexReader,
+        db_path: str | Path | None = None,
+    ):
+        self._library_manager = library_manager
+        resolved = Path(db_path) if db_path else _DEFAULT_DB_PATH
+        self._db = SymbolDatabase(str(resolved))
+
+    # ------------------------------------------------------------------
+    # Sync
+    # ------------------------------------------------------------------
+
+    def sync(
+        self,
+        force: bool = False,
+        diagnose: bool = False,
+        progress_callback=None,
+    ) -> SyncStats:
+        """
+        Sync the database with the current library table.
+
+        Change detection uses a two-stage strategy:
+        1. Fast path: if mtime and size match the DB → skip (no disk read).
+        2. Checksum path: if mtime or size differ, compute the file's SHA-256.
+           - Same checksum as stored → file content unchanged (e.g. file was
+             touched or copied); update mtime/size in DB without reparsing.
+           - Different checksum → content changed; fully reparse and reindex.
+
+        Pass force=True to bypass all change detection and reparse every file.
+        Pass diagnose=True to enable memory/object diagnostics during parsing.
+        Pass progress_callback(current, total, library_name) to receive
+        per-library progress notifications (called after each library is
+        processed, whether skipped, indexed, or failed).
+        """
+        t0 = time.time()
+        stats = SyncStats(
+            added=0, updated=0, removed=0, skipped=0,
+            failed=0, total_symbols=0, elapsed_seconds=0.0,
+        )
+
+        entries = self._library_manager.get_libraries()
+        db_known = self._db.get_library_states()   # {path: (id, mtime, size, checksum)}
+
+        current_paths: set[str] = set()
+
+        # Expand entries into (library_name, file_path) pairs.
+        # KiCad 10 sym-lib-table entries may point to a directory (.kicad_symdir)
+        # containing multiple .kicad_sym files rather than a single .kicad_sym file.
+        all_file_entries: list[tuple[str, str]] = []  # (library_name, file_path)
+        for entry in entries:
+            raw_path = entry.uri
+            if not raw_path:
+                continue
+            if os.path.isdir(raw_path):
+                try:
+                    for fname in sorted(os.listdir(raw_path)):
+                        if fname.endswith('.kicad_sym'):
+                            stem = fname[:-len('.kicad_sym')]
+                            lib_name = f"{entry.name}/{stem}"
+                            all_file_entries.append((lib_name, os.path.join(raw_path, fname)))
+                except OSError as exc:
+                    log.warning(f"Cannot list directory {raw_path}: {exc}")
+                    stats.failed += 1
+            else:
+                all_file_entries.append((entry.name, raw_path))
+
+        total = len(all_file_entries)
+
+        for i, (lib_name, path) in enumerate(all_file_entries):
+            if progress_callback is not None:
+                try:
+                    progress_callback(i, total, lib_name)
+                except Exception as exc:
+                    log.warning("progress_callback raised: %s", exc)
+            if not os.path.exists(path):
+                log.warning(f"[{i+1}/{total}] Skipping missing: {lib_name}")
+                stats.failed += 1
+                continue
+
+            current_paths.add(path)
+
+            try:
+                stat = os.stat(path)
+                cur_mtime: float = stat.st_mtime
+                cur_size: int = stat.st_size
+            except OSError as exc:
+                log.warning(f"[{i+1}/{total}] Cannot stat {path}: {exc}")
+                stats.failed += 1
+                continue
+
+            if path in db_known:
+                lib_id, db_mtime, db_size, db_checksum = db_known[path]
+
+                if not force and db_mtime == cur_mtime and db_size == cur_size:
+                    # Fast path: metadata identical → assume unchanged.
+                    log.debug(f"[{i+1}/{total}] Unchanged: {lib_name}")
+                    stats.skipped += 1
+                    continue
+
+                # Metadata changed — compare content via checksum before reparsing.
+                new_checksum = self._compute_checksum(path)
+                if not force and new_checksum == db_checksum and db_checksum != '':
+                    # File was touched/copied but content is identical → just
+                    # update the stored mtime/size so the fast path fires next time.
+                    log.debug(
+                        f"[{i+1}/{total}] Metadata changed, content unchanged: {lib_name}"
+                    )
+                    self._db.touch_library(lib_id, cur_mtime, cur_size, new_checksum)
+                    stats.skipped += 1
+                    continue
+
+                log.info(f"[{i+1}/{total}] Updating: {lib_name}")
+                n = self._index_library(
+                    lib_name, path, cur_mtime, cur_size, new_checksum,
+                    diagnose=diagnose,
+                )
+                if n >= 0:
+                    stats.updated += 1
+                    stats.total_symbols += n
+                else:
+                    stats.failed += 1
+            else:
+                log.info(f"[{i+1}/{total}] Adding: {lib_name}")
+                new_checksum = self._compute_checksum(path)
+                n = self._index_library(
+                    lib_name, path, cur_mtime, cur_size, new_checksum,
+                    diagnose=diagnose,
+                )
+                if n >= 0:
+                    stats.added += 1
+                    stats.total_symbols += n
+                else:
+                    stats.failed += 1
+
+        if progress_callback is not None:
+            try:
+                progress_callback(total, total, '')
+            except Exception as exc:
+                log.warning("progress_callback raised on completion: %s", exc)
+
+        # Remove libraries no longer in the table.
+        for path, (lib_id, _, _, _) in db_known.items():
+            if path not in current_paths:
+                log.info(f"Removing: {path}")
+                self._db.delete_library(lib_id)
+                stats.removed += 1
+
+        stats.elapsed_seconds = time.time() - t0
+        log.info(
+            f"Sync complete in {stats.elapsed_seconds:.2f}s — "
+            f"+{stats.added} added, ~{stats.updated} updated, "
+            f"-{stats.removed} removed, ={stats.skipped} unchanged, "
+            f"!{stats.failed} failed. "
+            f"Symbols indexed this run: {stats.total_symbols}"
+        )
+        return stats
+
+    def _index_library(
+        self,
+        library_name: str,
+        file_path: str,
+        mtime: float,
+        file_size: int,
+        checksum: str,
+        diagnose: bool = False,
+    ) -> int:
+        """
+        Parse a .kicad_sym file and persist the extracted symbols.
+        Returns the number of symbols stored, or -1 on error.
+        """
+        try:
+            symbols, kicad_version = self._parse_library(file_path, diagnose=diagnose)
+        except Exception as exc:
+            log.error(f"Parse failed for {file_path}: {exc}")
+            return -1
+
+        n = self._db.save_library(
+            library_name, file_path, mtime, file_size, kicad_version, symbols, checksum
+        )
+        log.info(f"  Indexed {n} symbols from {os.path.basename(file_path)}")
+        return n
+
+    # ------------------------------------------------------------------
+    # Library parsing (skip-library logic lives here, not in SymbolDatabase)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _compute_checksum(file_path: str) -> str:
+        """
+        Compute a SHA-256 digest of the file at file_path.
+        Read in chunks to avoid loading large library files fully into memory.
+        """
+        h = hashlib.sha256()
+        with open(file_path, 'rb') as f:
+            for chunk in iter(lambda: f.read(65536), b''):
+                h.update(chunk)
+        return h.hexdigest()
+
+    def _parse_library(
+        self, file_path: str, diagnose: bool = False,
+    ) -> tuple[list[SymbolRecord], str]:
+        """
+        Parse a .kicad_sym file and extract symbol metadata.
+
+        The SourceFile object (and its entire S-expression tree) is deleted
+        immediately after extraction so it can be garbage-collected.
+
+        Pass diagnose=True to print RSS / ParsedValue / pympler snapshots at
+        each major stage (same report as the former diagnose_single_library).
+
+        Returns (list[SymbolRecord], kicad_version_string).
+        """
+        def snapshot(label: str) -> None:
+            if not diagnose:
+                return
+            rss = _rss_mb()
+            pv = _parsed_value_count()
+            pv_str = f', ParsedValue live: {pv}' if pv is not None else ''
+            print(f'  [{label}] RSS: {rss:.1f} MB{pv_str}')
+
+        snapshot('before SourceFile()')
+        library_file = skip.sexp.sourcefile.SourceFile(file_path)
+        snapshot('after SourceFile()')
+
+        if diagnose and _asizeof is not None:
+            deep_mb = _asizeof.asizeof(library_file) / 1024 / 1024
+            print(f'  [deep size] pympler asizeof: {deep_mb:.1f} MB')
+
+        kicad_version = self._extract_version(library_file)
+        symbol_elements = self._get_symbol_elements(library_file)
+
+        if diagnose:
+            print(f'  [info] symbol count: {len(symbol_elements)}')
+
+        symbols: list[SymbolRecord] = []
+        for idx, sym_el in enumerate(symbol_elements):
+            try:
+                symbol_name = sym_el.value
+                if not symbol_name or not isinstance(symbol_name, str):
+                    continue
+
+                description, keywords = self._extract_properties(sym_el)
+                pin_count = len(sym_el.getElementsByEntityType('pin'))
+
+                symbols.append(SymbolRecord(
+                    library_name='',    # filled in by SymbolDatabase.save_library
+                    symbol_name=symbol_name,
+                    library_id=0,       # filled in by SymbolDatabase.save_library
+                    description=description,
+                    keywords=keywords,
+                    pin_count=pin_count,
+                    file_index=idx,
+                ))
+            except Exception as exc:
+                log.warning(f"Skipped symbol {idx} in {file_path}: {exc}")
+
+        snapshot('after extracting symbols (elements still alive)')
+
+        # Discard the S-expression tree so it can be garbage-collected.
+        del symbol_elements
+        snapshot('after del symbol_elements')
+        del library_file
+        snapshot('after del library_file (before any GC)')
+
+        if diagnose:
+            print('  [note] ParsedValue count may not drop until cyclic GC runs.')
+
+        return symbols, kicad_version
+
+    @staticmethod
+    def _extract_version(library_file: object) -> str:
+        """Extract the kicad_version string from the library file root."""
+        if hasattr(library_file, 'version'):
+            try:
+                return str(library_file.version.value)
+            except Exception as exc:
+                log.warning("Could not read kicad_version: %s", exc)
+        return ''
+
+    @staticmethod
+    def _get_symbol_elements(library_file: object) -> list:
+        """Return the list of top-level symbol ParsedValues."""
+        if not hasattr(library_file, 'symbol'):
+            return []
+        elements = library_file.symbol
+        # Could be a single ParsedValue, a plain list, or an ElementCollection.
+        if isinstance(elements, (list, skip.collection.ElementCollection)):
+            return elements
+        return [elements]
+
+    @staticmethod
+    def _extract_properties(sym_el: object) -> tuple[str, str]:
+        """
+        Walk the direct property children of a symbol element and extract
+        the Description and ki_keywords values.
+
+        KiCad property S-expression:
+            (property "Description" "Resistor" ...)
+        After parsing:
+            prop.children[0] = "Description"   (str, property name)
+            prop.children[1] = "Resistor"       (str, property value)
+        """
+        description = ''
+        keywords = ''
+        for prop in sym_el.getElementsByEntityType('property'):
+            children = prop.children
+            if len(children) < 2:
+                continue
+            prop_name = children[0] if isinstance(children[0], str) else ''
+            prop_val  = children[1] if isinstance(children[1], str) else ''
+            if prop_name in ('Description', 'ki_description'):
+                description = prop_val
+            elif prop_name == 'ki_keywords':
+                keywords = prop_val
+        return description, keywords
+
+    # ------------------------------------------------------------------
+    # Search
+    # ------------------------------------------------------------------
+
+    def search_symbols(self, query: str, limit: int = 50) -> list[SymbolRecord]:
+        """
+        Full-text search across symbol name, description, and keywords.
+        Results are ordered by relevance (FTS5 rank).
+        """
+        return self._db.search(query, limit=limit)
+
+    def search_by_name(
+        self,
+        name: str,
+        exact: bool = False,
+        limit: int = 50,
+    ) -> list[SymbolRecord]:
+        """
+        Search symbols by name.
+        exact=True  — case-insensitive whole-name match.
+        exact=False — case-insensitive substring match.
+        """
+        return self._db.search_by_name(name, exact=exact, limit=limit)
+
+    # ------------------------------------------------------------------
+    # Lookup
+    # ------------------------------------------------------------------
+
+    def get_symbol(self, library_name: str, symbol_name: str) -> SymbolRecord | None:
+        """Look up a single symbol by library and symbol name."""
+        return self._db.get_symbol(library_name, symbol_name)
+
+    def get_library_symbols(self, library_name: str) -> list[SymbolRecord]:
+        """Return all symbols in a library, ordered by position in file."""
+        return self._db.get_library_symbols(library_name)
+
+    def list_all_symbols(self) -> list[str]:
+        """Return all symbol keys as 'library_name:symbol_name' strings."""
+        return [
+            f'{s.library_name}:{s.symbol_name}'
+            for s in self._db.get_all_symbols()
+        ]
+
+    def get_all_libraries(self) -> list[LibraryRecord]:
+        """Return all indexed library records."""
+        return self._db.get_all_libraries()
+
+    def get_library_by_name(self, name: str) -> LibraryRecord | None:
+        """Look up a library record by library name."""
+        return self._db.get_library_by_name(name)
+
+    # ------------------------------------------------------------------
+    # Statistics
+    # ------------------------------------------------------------------
+
+    def get_statistics(self) -> DbStats:
+        """Return library and symbol counts from the database."""
+        return self._db.get_stats()
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def close(self) -> None:
+        """Close the database connection."""
+        self._db.close()

--- a/kicad_mcp/utils/symbol_index_reader.py
+++ b/kicad_mcp/utils/symbol_index_reader.py
@@ -1,0 +1,131 @@
+"""
+KiCad symbol library table reader.
+
+Reads the sym-lib-table file and expands environment variables in URIs.
+"""
+
+import os
+import re
+import logging
+from dataclasses import dataclass
+
+import skip.sexp.sourcefile
+from kicad_mcp.config import LibraryPathConfig
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Dataclass
+# ---------------------------------------------------------------------------
+
+@dataclass
+class LibraryTableEntry:
+    """One entry from the sym-lib-table file."""
+    name: str
+    lib_type: str
+    uri: str        # fully expanded (no ${VAR} placeholders)
+    options: str
+    descr: str
+
+
+# ---------------------------------------------------------------------------
+# SymbolIndexReader
+# ---------------------------------------------------------------------------
+
+class SymbolIndexReader:
+    """Reads the KiCad sym-lib-table file and returns its library entries."""
+
+    def __init__(self, config: LibraryPathConfig | None = None):
+        self._config = config or LibraryPathConfig()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def get_libraries(self) -> list[LibraryTableEntry]:
+        """Parse the sym-lib-table file and return all library entries."""
+        return self._parse_table()
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _parse_table(self) -> list[LibraryTableEntry]:
+        path = self._config.symbol_table_file
+        if not os.path.exists(path):
+            raise FileNotFoundError(f"sym-lib-table not found: {path}")
+        return self._parse_table_file(path, visited=set())
+
+    def _parse_table_file(
+        self,
+        path: str,
+        visited: set[str],
+    ) -> list[LibraryTableEntry]:
+        """
+        Parse a single sym-lib-table file and return its entries.
+
+        Entries whose type is ``"Table"`` are treated as indirection: their URI
+        is expanded, the referenced file is parsed recursively, and the nested
+        entries are spliced in-place of the indirection entry.  A ``visited``
+        set guards against circular references.
+        """
+        real_path = os.path.realpath(path)
+        if real_path in visited:
+            log.warning("Circular sym-lib-table reference detected, skipping: %s", path)
+            return []
+        visited.add(real_path)
+
+        log.info("Parsing sym-lib-table: %s", path)
+        table = skip.sexp.sourcefile.SourceFile(path)
+        entries: list[LibraryTableEntry] = []
+
+        if not hasattr(table, 'lib'):
+            log.info("No library entries found in: %s", path)
+            return entries
+
+        # skip returns a bare ParsedValue node when there is only one lib entry,
+        # and an ElementCollection when there are multiple. Normalise to iterable.
+        import skip.sexp.parser as _sp
+        raw = table.lib
+        libs = [raw] if isinstance(raw, _sp.ParsedValue) else raw
+        for lib in libs:
+            name     = lib.name.value    if hasattr(lib, 'name')    and hasattr(lib.name,    'value') else ''
+            lib_type = lib.type.value    if hasattr(lib, 'type')    and hasattr(lib.type,    'value') else ''
+            uri      = lib.uri.value     if hasattr(lib, 'uri')     and hasattr(lib.uri,     'value') else ''
+            options  = lib.options.value if hasattr(lib, 'options') and hasattr(lib.options, 'value') else ''
+            descr    = lib.descr.value   if hasattr(lib, 'descr')   and hasattr(lib.descr,   'value') else ''
+
+            if uri:
+                uri = self._expand_env_vars(uri)
+
+            # KiCad 10+: a "Table" entry redirects to another sym-lib-table file.
+            if lib_type.lower() == "table":
+                if os.path.isfile(uri):
+                    log.info("Following sym-lib-table indirection: %s -> %s", path, uri)
+                    entries.extend(self._parse_table_file(uri, visited))
+                else:
+                    log.warning("sym-lib-table indirection target not found: %s", uri)
+                continue
+
+            if lib_type.lower() != "kicad":
+                log.info("Skipping non-KiCad library entry '%s' (type=%s)", name, lib_type)
+                continue
+
+            log.info("Found library '%s': %s", name, uri)
+            entries.append(LibraryTableEntry(
+                name=name,
+                lib_type=lib_type,
+                uri=uri,
+                options=options,
+                descr=descr,
+            ))
+
+        log.info("Loaded %d librar%s from: %s", len(entries), 'y' if len(entries) == 1 else 'ies', path)
+        return entries
+
+    def _expand_env_vars(self, path: str) -> str:
+        """Replace ${VAR_NAME} placeholders using the configured env vars."""
+        for var, value in self._config.get_env_vars().items():
+            path = re.sub(r'\$\{' + re.escape(var) + r'\}', value, path)
+        return path

--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ logging.basicConfig(
     format='%(asctime)s - %(levelname)s - [PID:%(process)d] - %(message)s',
     handlers=[
         logging.FileHandler(log_file, mode='w'), # Use 'w' to overwrite log on each start
-        # logging.StreamHandler() # Optionally keep logging to console if needed
+        logging.StreamHandler() # Optionally keep logging to console if needed
     ]
 )
 # ---------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,8 @@ dependencies = [
     "pandas>=2.0.0",
     "pyyaml>=6.0.0",
     "defusedxml>=0.7.0",  # Secure XML parsing
+    "kicad-skip>=0.2.5",  # KiCad S-expression file parser (imports as `skip`)
+    "sqlalchemy>=2.0.0",  # Symbol database ORM
 ]
 
 [project.urls]

--- a/tests/unit/tools/test_symbol_tools.py
+++ b/tests/unit/tools/test_symbol_tools.py
@@ -232,7 +232,7 @@ class TestGetSymbol:
             result = _call("get_symbol", library_name="Device", symbol_name="R")
 
         assert result["success"] is True
-        assert result["library"] == "Device"
+        assert result["library_name"] == "Device"
         assert result["name"] == "R"
         assert result["pin_count"] == 2
 
@@ -321,7 +321,7 @@ class TestGetLibrarySymbols:
             result = _call("get_library_symbols", library_name="Device")
 
         assert result["success"] is True
-        assert result["library"] == "Device"
+        assert result["library_name"] == "Device"
         assert result["count"] == 2
         names = [s["name"] for s in result["symbols"]]
         assert "R" in names

--- a/tests/unit/tools/test_symbol_tools.py
+++ b/tests/unit/tools/test_symbol_tools.py
@@ -1,0 +1,365 @@
+"""
+Unit tests for kicad_mcp/tools/symbol_tools.py.
+
+Patches the module-level _index_manager singleton and _sync_state so tests
+are fully self-contained and do not require a real KiCad installation.
+"""
+
+import asyncio
+import threading
+from dataclasses import dataclass
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# MockMCP — captures @mcp.tool()-decorated coroutines
+# ---------------------------------------------------------------------------
+
+class _MockMCP:
+    """Minimal FastMCP stand-in that captures @mcp.tool()-decorated functions."""
+
+    def __init__(self):
+        self.tools: dict = {}
+
+    def tool(self):
+        def decorator(fn):
+            self.tools[fn.__name__] = fn
+            return fn
+        return decorator
+
+
+def _get_tools() -> dict:
+    """Register symbol tools against a mock MCP and return the captured dict."""
+    from kicad_mcp.tools.symbol_tools import register_symbol_tools
+    mock = _MockMCP()
+    register_symbol_tools(mock)
+    return mock.tools
+
+
+# Lazily-created module-level tools dict (avoids repeated registration).
+_tools: dict = {}
+
+
+def _tools_dict() -> dict:
+    global _tools
+    if not _tools:
+        _tools = _get_tools()
+    return _tools
+
+
+def _call(name, **kwargs):
+    """Helper: call a tool by name synchronously via asyncio.run()."""
+    return asyncio.run(_tools_dict()[name](**kwargs))
+
+
+# ---------------------------------------------------------------------------
+# TestSyncSymbolIndex
+# ---------------------------------------------------------------------------
+
+
+class TestSyncSymbolIndex:
+    """Tests for sync_symbol_index()."""
+
+    def test_starts_when_idle(self):
+        """When no sync is running, sync_symbol_index should start a thread."""
+        import kicad_mcp.tools.symbol_tools as mod
+
+        # Reset state to idle.
+        with mod._sync_lock:
+            mod._sync_state.running = False
+            mod._sync_state.current = 0
+            mod._sync_state.total = 0
+            mod._sync_state.current_library = ''
+            mod._sync_state.error = None
+
+        with patch.object(threading, "Thread") as mock_thread_cls:
+            mock_thread = MagicMock()
+            mock_thread_cls.return_value = mock_thread
+
+            result = _call("sync_symbol_index", force=False)
+
+        assert result["status"] == "started"
+        mock_thread.start.assert_called_once()
+
+        # Clean up: mark as not running so other tests don't see stale state.
+        with mod._sync_lock:
+            mod._sync_state.running = False
+
+    def test_already_running(self):
+        """When a sync is already running, return already_running status."""
+        import kicad_mcp.tools.symbol_tools as mod
+
+        with mod._sync_lock:
+            mod._sync_state.running = True
+            mod._sync_state.current = 5
+            mod._sync_state.total = 20
+
+        try:
+            result = _call("sync_symbol_index")
+            assert result["status"] == "already_running"
+            assert "current" in result
+        finally:
+            with mod._sync_lock:
+                mod._sync_state.running = False
+
+
+# ---------------------------------------------------------------------------
+# TestGetSymbolSyncStatus
+# ---------------------------------------------------------------------------
+
+
+class TestGetSymbolSyncStatus:
+    """Tests for get_symbol_sync_status()."""
+
+    def test_idle_state(self):
+        """Default state should show running=False."""
+        import kicad_mcp.tools.symbol_tools as mod
+
+        with mod._sync_lock:
+            mod._sync_state.running = False
+            mod._sync_state.current = 0
+            mod._sync_state.total = 0
+            mod._sync_state.current_library = ''
+            mod._sync_state.last_result = None
+            mod._sync_state.error = None
+
+        result = _call("get_symbol_sync_status")
+        assert result["running"] is False
+        assert result["current"] == 0
+        assert result["total"] == 0
+
+    def test_running_state(self):
+        """Should reflect whatever state _sync_state holds."""
+        import kicad_mcp.tools.symbol_tools as mod
+
+        with mod._sync_lock:
+            mod._sync_state.running = True
+            mod._sync_state.current = 3
+            mod._sync_state.total = 10
+            mod._sync_state.current_library = "Device"
+            mod._sync_state.last_result = None
+            mod._sync_state.error = None
+
+        try:
+            result = _call("get_symbol_sync_status")
+            assert result["running"] is True
+            assert result["current"] == 3
+            assert result["total"] == 10
+            assert result["current_library"] == "Device"
+        finally:
+            with mod._sync_lock:
+                mod._sync_state.running = False
+
+
+# ---------------------------------------------------------------------------
+# TestSearchSymbols
+# ---------------------------------------------------------------------------
+
+
+class TestSearchSymbols:
+    """Tests for search_symbols()."""
+
+    def _make_symbol_record(self, lib="Device", name="R", desc="Resistor", kw="res", pins=2):
+        r = MagicMock()
+        r.library_name = lib
+        r.symbol_name = name
+        r.description = desc
+        r.keywords = kw
+        r.pin_count = pins
+        return r
+
+    def test_returns_results(self):
+        rec1 = self._make_symbol_record("Device", "R", "Resistor", "res", 2)
+        rec2 = self._make_symbol_record("Device", "C", "Capacitor", "cap", 2)
+
+        mock_mgr = MagicMock()
+        mock_mgr.search_symbols.return_value = [rec1, rec2]
+
+        with patch("kicad_mcp.tools.symbol_tools._get_index_manager", return_value=mock_mgr):
+            result = _call("search_symbols", query="passive")
+
+        assert result["success"] is True
+        assert result["count"] == 2
+        assert result["symbols"][0]["name"] == "R"
+        assert result["symbols"][1]["name"] == "C"
+        mock_mgr.search_symbols.assert_called_once_with("passive", limit=50)
+
+    def test_empty_results(self):
+        mock_mgr = MagicMock()
+        mock_mgr.search_symbols.return_value = []
+
+        with patch("kicad_mcp.tools.symbol_tools._get_index_manager", return_value=mock_mgr):
+            result = _call("search_symbols", query="xyzzy_no_match")
+
+        assert result["success"] is True
+        assert result["count"] == 0
+        assert result["symbols"] == []
+
+    def test_manager_error(self):
+        mock_mgr = MagicMock()
+        mock_mgr.search_symbols.side_effect = RuntimeError("DB locked")
+
+        with patch("kicad_mcp.tools.symbol_tools._get_index_manager", return_value=mock_mgr):
+            result = _call("search_symbols", query="anything")
+
+        assert result["success"] is False
+        assert "DB locked" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# TestGetSymbol
+# ---------------------------------------------------------------------------
+
+
+class TestGetSymbol:
+    """Tests for get_symbol()."""
+
+    def test_found(self):
+        rec = MagicMock()
+        rec.library_name = "Device"
+        rec.symbol_name = "R"
+        rec.description = "Resistor"
+        rec.keywords = "res passive"
+        rec.pin_count = 2
+
+        mock_mgr = MagicMock()
+        mock_mgr.get_symbol.return_value = rec
+
+        with patch("kicad_mcp.tools.symbol_tools._get_index_manager", return_value=mock_mgr):
+            result = _call("get_symbol", library_name="Device", symbol_name="R")
+
+        assert result["success"] is True
+        assert result["library"] == "Device"
+        assert result["name"] == "R"
+        assert result["pin_count"] == 2
+
+    def test_not_found(self):
+        mock_mgr = MagicMock()
+        mock_mgr.get_symbol.return_value = None
+
+        with patch("kicad_mcp.tools.symbol_tools._get_index_manager", return_value=mock_mgr):
+            result = _call("get_symbol", library_name="Device", symbol_name="NOEXIST")
+
+        assert result["success"] is False
+        assert "not found" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# TestListSymbolLibraries
+# ---------------------------------------------------------------------------
+
+
+class TestListSymbolLibraries:
+    """Tests for list_symbol_libraries()."""
+
+    def test_returns_libraries(self):
+        lib1 = MagicMock()
+        lib1.library_name = "Device"
+        lib1.file_path = "/usr/share/kicad/symbols/Device.kicad_sym"
+        lib1.symbol_count = 500
+        lib1.kicad_version = "7.0"
+
+        lib2 = MagicMock()
+        lib2.library_name = "Connector"
+        lib2.file_path = "/usr/share/kicad/symbols/Connector.kicad_sym"
+        lib2.symbol_count = 300
+        lib2.kicad_version = "7.0"
+
+        mock_mgr = MagicMock()
+        mock_mgr.get_all_libraries.return_value = [lib1, lib2]
+
+        with patch("kicad_mcp.tools.symbol_tools._get_index_manager", return_value=mock_mgr):
+            result = _call("list_symbol_libraries")
+
+        assert result["success"] is True
+        assert result["count"] == 2
+        names = [lib["name"] for lib in result["libraries"]]
+        assert "Device" in names
+        assert "Connector" in names
+        first = result["libraries"][0]
+        assert "path" in first
+        assert "symbol_count" in first
+        assert "kicad_version" in first
+
+    def test_empty_libraries(self):
+        mock_mgr = MagicMock()
+        mock_mgr.get_all_libraries.return_value = []
+
+        with patch("kicad_mcp.tools.symbol_tools._get_index_manager", return_value=mock_mgr):
+            result = _call("list_symbol_libraries")
+
+        assert result["success"] is True
+        assert result["count"] == 0
+        assert result["libraries"] == []
+
+
+# ---------------------------------------------------------------------------
+# TestGetLibrarySymbols
+# ---------------------------------------------------------------------------
+
+
+class TestGetLibrarySymbols:
+    """Tests for get_library_symbols()."""
+
+    def _make_sym(self, name, desc="", kw="", pins=2):
+        s = MagicMock()
+        s.symbol_name = name
+        s.description = desc
+        s.keywords = kw
+        s.pin_count = pins
+        return s
+
+    def test_found(self):
+        syms = [self._make_sym("R"), self._make_sym("R_Small")]
+        mock_mgr = MagicMock()
+        mock_mgr.get_library_symbols.return_value = syms
+
+        with patch("kicad_mcp.tools.symbol_tools._get_index_manager", return_value=mock_mgr):
+            result = _call("get_library_symbols", library_name="Device")
+
+        assert result["success"] is True
+        assert result["library"] == "Device"
+        assert result["count"] == 2
+        names = [s["name"] for s in result["symbols"]]
+        assert "R" in names
+
+    def test_not_found(self):
+        mock_mgr = MagicMock()
+        mock_mgr.get_library_symbols.return_value = []
+
+        with patch("kicad_mcp.tools.symbol_tools._get_index_manager", return_value=mock_mgr):
+            result = _call("get_library_symbols", library_name="NOLIB")
+
+        assert result["success"] is False
+        assert "NOLIB" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# TestGetSymbolIndexStats
+# ---------------------------------------------------------------------------
+
+
+class TestGetSymbolIndexStats:
+    """Tests for get_symbol_index_stats()."""
+
+    def test_returns_stats(self):
+        stats = MagicMock()
+        stats.library_count = 42
+        stats.symbol_count = 12345
+        stats.last_sync = "2025-01-01T00:00:00"
+        stats.db_path = "/home/user/.kicad_mcp/symbols.db"
+
+        mock_mgr = MagicMock()
+        mock_mgr.get_statistics.return_value = stats
+
+        with patch("kicad_mcp.tools.symbol_tools._get_index_manager", return_value=mock_mgr):
+            result = _call("get_symbol_index_stats")
+
+        assert result["success"] is True
+        assert result["library_count"] == 42
+        assert result["symbol_count"] == 12345
+        assert result["last_sync"] == "2025-01-01T00:00:00"
+        assert result["db_path"] == "/home/user/.kicad_mcp/symbols.db"

--- a/tests/unit/utils/fixtures/sym-lib-table
+++ b/tests/unit/utils/fixtures/sym-lib-table
@@ -1,0 +1,4 @@
+(sym_lib_table
+  (lib (name "TestDevice")(type "KiCad")(uri "${KICAD_TEST_FIXTURES_DIR}/test_device.kicad_sym")(options "")(descr "Test discrete components"))
+  (lib (name "TestPower")(type "KiCad")(uri "${KICAD_TEST_FIXTURES_DIR}/test_power.kicad_sym")(options "")(descr "Test power symbols"))
+)

--- a/tests/unit/utils/fixtures/test_device.kicad_sym
+++ b/tests/unit/utils/fixtures/test_device.kicad_sym
@@ -1,0 +1,246 @@
+(kicad_symbol_lib
+  (version 20220914)
+  (generator kicad_symbol_editor)
+  (symbol "R"
+    (pin_names
+      (offset 0)
+    )
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (property "Reference" "R"
+      (at 0 1.905 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "R"
+      (at 0 0 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 0 0 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 0 0 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Description" "Resistor"
+      (at 0 0 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "ki_keywords" "R resistor"
+      (at 0 0 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (symbol "R_0_1"
+      (polyline
+        (pts
+          (xy -1.016 -0.762)
+          (xy -1.016 0.762)
+          (xy 1.016 0.762)
+          (xy 1.016 -0.762)
+          (xy -1.016 -0.762)
+        )
+        (stroke
+          (width 0)
+          (type default)
+        )
+        (fill
+          (type none)
+        )
+      )
+    )
+    (symbol "R_1_1"
+      (pin passive line
+        (at 0 2.54 270)
+        (length 1.524)
+        (name "~"
+          (effects
+            (font
+              (size 1.27 1.27)
+            )
+          )
+        )
+        (number "1"
+          (effects
+            (font
+              (size 1.27 1.27)
+            )
+          )
+        )
+      )
+      (pin passive line
+        (at 0 -2.54 90)
+        (length 1.524)
+        (name "~"
+          (effects
+            (font
+              (size 1.27 1.27)
+            )
+          )
+        )
+        (number "2"
+          (effects
+            (font
+              (size 1.27 1.27)
+            )
+          )
+        )
+      )
+    )
+  )
+  (symbol "C"
+    (pin_names
+      (offset 0.254)
+    )
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (property "Reference" "C"
+      (at 0 2.54 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Value" "C"
+      (at 0 -2.54 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 0 0 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" "~"
+      (at 0 0 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Description" "Capacitor"
+      (at 0 0 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "ki_keywords" "C capacitor"
+      (at 0 0 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (symbol "C_0_1"
+      (polyline
+        (pts
+          (xy -1.524 0.508)
+          (xy 1.524 0.508)
+        )
+        (stroke
+          (width 0.508)
+          (type default)
+        )
+        (fill
+          (type none)
+        )
+      )
+      (polyline
+        (pts
+          (xy -1.524 -0.508)
+          (xy 1.524 -0.508)
+        )
+        (stroke
+          (width 0.508)
+          (type default)
+        )
+        (fill
+          (type none)
+        )
+      )
+    )
+    (symbol "C_1_1"
+      (pin passive line
+        (at 0 2.54 270)
+        (length 2.032)
+        (name "~"
+          (effects
+            (font
+              (size 1.27 1.27)
+            )
+          )
+        )
+        (number "1"
+          (effects
+            (font
+              (size 1.27 1.27)
+            )
+          )
+        )
+      )
+      (pin passive line
+        (at 0 -2.54 90)
+        (length 2.032)
+        (name "~"
+          (effects
+            (font
+              (size 1.27 1.27)
+            )
+          )
+        )
+        (number "2"
+          (effects
+            (font
+              (size 1.27 1.27)
+            )
+          )
+        )
+      )
+    )
+  )
+)

--- a/tests/unit/utils/fixtures/test_power.kicad_sym
+++ b/tests/unit/utils/fixtures/test_power.kicad_sym
@@ -1,0 +1,200 @@
+(kicad_symbol_lib
+  (version 20220914)
+  (generator kicad_symbol_editor)
+  (symbol "VCC"
+    (pin_names
+      (offset 0)
+      (hide yes)
+    )
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (property "Reference" "#PWR"
+      (at 0 -1.905 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Value" "VCC"
+      (at 0 1.905 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 0 0 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" ""
+      (at 0 0 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Description" "Power supply positive"
+      (at 0 0 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "ki_keywords" "power VCC supply positive"
+      (at 0 0 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (symbol "VCC_0_1"
+      (polyline
+        (pts
+          (xy -0.762 0.508)
+          (xy 0 1.524)
+          (xy 0.762 0.508)
+        )
+        (stroke
+          (width 0)
+          (type default)
+        )
+        (fill
+          (type none)
+        )
+      )
+    )
+    (symbol "VCC_1_1"
+      (pin power_in line
+        (at 0 0 90)
+        (length 0)
+        (name "~"
+          (effects
+            (font
+              (size 1.27 1.27)
+            )
+          )
+        )
+        (number "1"
+          (effects
+            (font
+              (size 1.27 1.27)
+            )
+          )
+        )
+      )
+    )
+  )
+  (symbol "GND"
+    (pin_names
+      (offset 0)
+      (hide yes)
+    )
+    (exclude_from_sim no)
+    (in_bom yes)
+    (on_board yes)
+    (property "Reference" "#PWR"
+      (at 0 1.905 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Value" "GND"
+      (at 0 -1.905 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+      )
+    )
+    (property "Footprint" ""
+      (at 0 0 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Datasheet" ""
+      (at 0 0 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "Description" "Power supply ground"
+      (at 0 0 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (property "ki_keywords" "power GND ground"
+      (at 0 0 0)
+      (effects
+        (font
+          (size 1.27 1.27)
+        )
+        (hide yes)
+      )
+    )
+    (symbol "GND_0_1"
+      (polyline
+        (pts
+          (xy -0.762 -0.508)
+          (xy 0 -1.524)
+          (xy 0.762 -0.508)
+        )
+        (stroke
+          (width 0)
+          (type default)
+        )
+        (fill
+          (type none)
+        )
+      )
+    )
+    (symbol "GND_1_1"
+      (pin power_in line
+        (at 0 0 270)
+        (length 0)
+        (name "~"
+          (effects
+            (font
+              (size 1.27 1.27)
+            )
+          )
+        )
+        (number "1"
+          (effects
+            (font
+              (size 1.27 1.27)
+            )
+          )
+        )
+      )
+    )
+  )
+)

--- a/tests/unit/utils/test_symbol_database.py
+++ b/tests/unit/utils/test_symbol_database.py
@@ -1,0 +1,308 @@
+"""
+Tests for SymbolDatabase — SQLAlchemy/SQLite storage layer for indexed symbols.
+"""
+
+import pytest
+
+from kicad_mcp.utils.symbol_database import SymbolDatabase, SymbolRecord
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_symbols(library_name: str, entries: list[tuple]) -> list[SymbolRecord]:
+    """
+    Build a list of SymbolRecord objects.
+
+    Each entry is a (symbol_name, description, keywords, pin_count) tuple.
+    The library_name and library_id fields are placeholders — SymbolDatabase
+    overwrites them with real values during save_library().
+    """
+    return [
+        SymbolRecord(
+            library_name=library_name,
+            symbol_name=name,
+            library_id=0,
+            description=desc,
+            keywords=kw,
+            pin_count=pins,
+            file_index=idx,
+        )
+        for idx, (name, desc, kw, pins) in enumerate(entries)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db():
+    d = SymbolDatabase(":memory:")
+    yield d
+    d.close()
+
+
+# ---------------------------------------------------------------------------
+# Empty database state
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyDatabase:
+    def test_stats_are_zero(self, db):
+        stats = db.get_stats()
+        assert stats.library_count == 0
+        assert stats.symbol_count == 0
+        assert stats.last_sync == 0.0
+
+    def test_library_states_empty(self, db):
+        assert db.get_library_states() == {}
+
+    def test_get_all_symbols_empty(self, db):
+        assert db.get_all_symbols() == []
+
+    def test_get_all_libraries_empty(self, db):
+        assert db.get_all_libraries() == []
+
+    def test_get_symbol_returns_none(self, db):
+        assert db.get_symbol("Lib", "R") is None
+
+    def test_get_library_by_name_returns_none(self, db):
+        assert db.get_library_by_name("Lib") is None
+
+
+# ---------------------------------------------------------------------------
+# save_library
+# ---------------------------------------------------------------------------
+
+
+class TestSaveLibrary:
+    def test_returns_symbol_count(self, db):
+        syms = _make_symbols("Lib", [("R", "Resistor", "R resistor", 2)])
+        n = db.save_library("Lib", "/tmp/lib.kicad_sym", 1000.0, 500, "20241101", syms)
+        assert n == 1
+
+    def test_library_appears_in_states(self, db):
+        syms = _make_symbols("Lib", [("R", "Resistor", "R", 2)])
+        db.save_library("Lib", "/tmp/lib.kicad_sym", 1000.0, 500, "", syms)
+        states = db.get_library_states()
+        assert "/tmp/lib.kicad_sym" in states
+
+    def test_multiple_symbols_stored(self, db):
+        syms = _make_symbols("Dev", [
+            ("R", "Resistor", "R resistor", 2),
+            ("C", "Capacitor", "C capacitor", 2),
+        ])
+        db.save_library("Dev", "/tmp/dev.kicad_sym", 1.0, 100, "", syms)
+        stored = db.get_library_symbols("Dev")
+        assert len(stored) == 2
+
+    def test_replace_existing_library(self, db):
+        """Saving to the same path again replaces all previous symbols."""
+        syms1 = _make_symbols("Lib", [("R", "Resistor", "", 2)])
+        db.save_library("Lib", "/tmp/lib.kicad_sym", 1.0, 100, "", syms1)
+
+        syms2 = _make_symbols("Lib", [("C", "Capacitor", "", 2)])
+        db.save_library("Lib", "/tmp/lib.kicad_sym", 2.0, 100, "", syms2)
+
+        stored = db.get_library_symbols("Lib")
+        assert len(stored) == 1
+        assert stored[0].symbol_name == "C"
+
+    def test_stats_updated_after_save(self, db):
+        syms = _make_symbols("Lib", [("R", "Res", "", 2), ("C", "Cap", "", 2)])
+        db.save_library("Lib", "/tmp/lib.kicad_sym", 1.0, 100, "", syms)
+        stats = db.get_stats()
+        assert stats.library_count == 1
+        assert stats.symbol_count == 2
+        assert stats.last_sync > 0.0
+
+    def test_two_libraries_independent(self, db):
+        db.save_library(
+            "DevLib", "/tmp/dev.kicad_sym", 1.0, 100, "",
+            _make_symbols("DevLib", [("R", "Resistor", "", 2)]),
+        )
+        db.save_library(
+            "PwrLib", "/tmp/pwr.kicad_sym", 1.0, 100, "",
+            _make_symbols("PwrLib", [("VCC", "VCC", "", 1)]),
+        )
+        stats = db.get_stats()
+        assert stats.library_count == 2
+        assert stats.symbol_count == 2
+
+
+# ---------------------------------------------------------------------------
+# touch_library
+# ---------------------------------------------------------------------------
+
+
+class TestTouchLibrary:
+    def test_touch_updates_mtime(self, db):
+        syms = _make_symbols("Lib", [("R", "Resistor", "", 2)])
+        db.save_library("Lib", "/tmp/lib.kicad_sym", 1.0, 100, "abc", syms)
+        lib = db.get_library_by_name("Lib")
+        db.touch_library(lib.id, 999.0, 200, "xyz")
+        states = db.get_library_states()
+        _id, mtime, size, checksum = states["/tmp/lib.kicad_sym"]
+        assert mtime == 999.0
+        assert size == 200
+        assert checksum == "xyz"
+
+
+# ---------------------------------------------------------------------------
+# delete_library
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteLibrary:
+    def test_delete_removes_library_and_symbols(self, db):
+        syms = _make_symbols("Lib", [("R", "Resistor", "", 2)])
+        db.save_library("Lib", "/tmp/lib.kicad_sym", 1.0, 100, "", syms)
+
+        lib = db.get_library_by_name("Lib")
+        assert lib is not None
+        db.delete_library(lib.id)
+
+        assert db.get_library_by_name("Lib") is None
+        assert db.get_library_symbols("Lib") == []
+
+    def test_delete_updates_stats(self, db):
+        syms = _make_symbols("Lib", [("R", "Res", "", 2)])
+        db.save_library("Lib", "/tmp/lib.kicad_sym", 1.0, 100, "", syms)
+        lib = db.get_library_by_name("Lib")
+        db.delete_library(lib.id)
+        stats = db.get_stats()
+        assert stats.library_count == 0
+        assert stats.symbol_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Lookup
+# ---------------------------------------------------------------------------
+
+
+class TestLookup:
+    @pytest.fixture(autouse=True)
+    def _populate(self, db):
+        self.db = db
+        db.save_library(
+            "Dev", "/tmp/dev.kicad_sym", 1.0, 100, "",
+            _make_symbols("Dev", [
+                ("R", "Resistor", "R resistor passive", 2),
+                ("C", "Capacitor", "C capacitor passive", 2),
+            ]),
+        )
+        db.save_library(
+            "Pwr", "/tmp/pwr.kicad_sym", 1.0, 100, "",
+            _make_symbols("Pwr", [
+                ("VCC", "Power supply positive", "power VCC supply", 1),
+                ("GND", "Power supply ground", "power GND ground", 1),
+            ]),
+        )
+
+    def test_get_symbol_found(self):
+        sym = self.db.get_symbol("Dev", "R")
+        assert sym is not None
+        assert sym.description == "Resistor"
+        assert sym.pin_count == 2
+
+    def test_get_symbol_not_found(self):
+        assert self.db.get_symbol("Dev", "NONEXISTENT") is None
+
+    def test_get_symbol_wrong_library(self):
+        assert self.db.get_symbol("Pwr", "R") is None
+
+    def test_get_library_symbols_count(self):
+        syms = self.db.get_library_symbols("Dev")
+        assert len(syms) == 2
+
+    def test_get_library_symbols_order(self):
+        syms = self.db.get_library_symbols("Dev")
+        assert [s.symbol_name for s in syms] == ["R", "C"]
+
+    def test_get_all_symbols_total(self):
+        all_syms = self.db.get_all_symbols()
+        assert len(all_syms) == 4
+
+    def test_get_all_libraries(self):
+        libs = self.db.get_all_libraries()
+        assert len(libs) == 2
+        names = {lib.library_name for lib in libs}
+        assert names == {"Dev", "Pwr"}
+
+    def test_get_library_by_name(self):
+        lib = self.db.get_library_by_name("Pwr")
+        assert lib is not None
+        assert lib.symbol_count == 2
+
+    def test_get_symbol_file_index(self):
+        idx = self.db.get_symbol_file_index("Dev", "C")
+        assert idx == 1
+
+    def test_get_symbol_file_index_not_found(self):
+        assert self.db.get_symbol_file_index("Dev", "MISSING") is None
+
+
+# ---------------------------------------------------------------------------
+# Search
+# ---------------------------------------------------------------------------
+
+
+class TestSearchByName:
+    @pytest.fixture(autouse=True)
+    def _populate(self, db):
+        self.db = db
+        db.save_library(
+            "Dev", "/tmp/dev.kicad_sym", 1.0, 100, "",
+            _make_symbols("Dev", [
+                ("R", "Resistor", "R resistor", 2),
+                ("C", "Capacitor", "C capacitor", 2),
+                ("VCC", "Power positive", "power VCC", 1),
+            ]),
+        )
+
+    def test_substring_match(self):
+        results = self.db.search_by_name("CC")
+        names = {r.symbol_name for r in results}
+        assert "VCC" in names
+
+    def test_exact_match(self):
+        results = self.db.search_by_name("R", exact=True)
+        assert len(results) == 1
+        assert results[0].symbol_name == "R"
+
+    def test_exact_match_case_insensitive(self):
+        results = self.db.search_by_name("r", exact=True)
+        assert len(results) == 1
+
+    def test_no_match_returns_empty(self):
+        results = self.db.search_by_name("ZZZNOMATCH")
+        assert results == []
+
+
+class TestFTSSearch:
+    @pytest.fixture(autouse=True)
+    def _populate(self, db):
+        self.db = db
+        db.save_library(
+            "Dev", "/tmp/dev.kicad_sym", 1.0, 100, "",
+            _make_symbols("Dev", [
+                ("R", "Resistor", "R resistor passive", 2),
+                ("C", "Capacitor", "C capacitor passive", 2),
+            ]),
+        )
+
+    def test_search_by_description_word(self):
+        results = self.db.search("Resistor")
+        assert any(r.symbol_name == "R" for r in results)
+
+    def test_search_by_keyword(self):
+        results = self.db.search("capacitor")
+        assert any(r.symbol_name == "C" for r in results)
+
+    def test_search_no_match(self):
+        results = self.db.search("xyzzy_no_match_ever")
+        assert results == []

--- a/tests/unit/utils/test_symbol_index_manager.py
+++ b/tests/unit/utils/test_symbol_index_manager.py
@@ -1,0 +1,211 @@
+"""
+Tests for SymbolIndexManager — orchestrates sym-lib-table reading, .kicad_sym
+parsing, and database storage through sync() and search/lookup methods.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from kicad_mcp.config import LibraryPathConfig
+from kicad_mcp.utils.symbol_index_reader import SymbolIndexReader
+from kicad_mcp.utils.symbol_index_manager import SymbolIndexManager
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+# ---------------------------------------------------------------------------
+# Test config / helpers
+# ---------------------------------------------------------------------------
+
+
+class _FixtureConfig(LibraryPathConfig):
+    """LibraryPathConfig subclass pointing at the test fixture directory."""
+
+    def __init__(self):
+        super().__init__()
+
+    @property
+    def symbol_table_file(self) -> str:
+        return str(FIXTURES_DIR / "sym-lib-table")
+
+    def get_env_vars(self) -> dict:
+        return {"KICAD_TEST_FIXTURES_DIR": str(FIXTURES_DIR)}
+
+
+def _make_manager() -> SymbolIndexManager:
+    reader = SymbolIndexReader(_FixtureConfig())
+    return SymbolIndexManager(reader, db_path=":memory:")
+
+
+# ---------------------------------------------------------------------------
+# Sync — initial run
+# ---------------------------------------------------------------------------
+
+
+class TestSyncInitial:
+    def setup_method(self):
+        self.mgr = _make_manager()
+
+    def test_sync_adds_two_libraries(self):
+        stats = self.mgr.sync()
+        assert stats.added == 2
+
+    def test_sync_no_failures(self):
+        stats = self.mgr.sync()
+        assert stats.failed == 0
+
+    def test_sync_total_symbols(self):
+        """Fixtures: TestDevice (R, C) + TestPower (VCC, GND) = 4 symbols."""
+        stats = self.mgr.sync()
+        assert stats.total_symbols == 4
+
+    def test_sync_elapsed_positive(self):
+        stats = self.mgr.sync()
+        assert stats.elapsed_seconds > 0.0
+
+    def test_sync_zero_updated_on_first_run(self):
+        stats = self.mgr.sync()
+        assert stats.updated == 0
+
+    def test_sync_zero_removed_on_first_run(self):
+        stats = self.mgr.sync()
+        assert stats.removed == 0
+
+    def test_sync_zero_skipped_on_first_run(self):
+        stats = self.mgr.sync()
+        assert stats.skipped == 0
+
+
+# ---------------------------------------------------------------------------
+# Sync — incremental (second call must skip unchanged files)
+# ---------------------------------------------------------------------------
+
+
+class TestSyncIncremental:
+    def setup_method(self):
+        self.mgr = _make_manager()
+        self.mgr.sync()  # first sync — loads everything
+
+    def test_second_sync_skips_all_libraries(self):
+        stats = self.mgr.sync()
+        assert stats.skipped == 2
+
+    def test_second_sync_adds_nothing(self):
+        stats = self.mgr.sync()
+        assert stats.added == 0
+
+    def test_second_sync_no_failures(self):
+        stats = self.mgr.sync()
+        assert stats.failed == 0
+
+    def test_force_sync_reparses_all(self):
+        stats = self.mgr.sync(force=True)
+        assert stats.updated == 2
+        assert stats.skipped == 0
+
+    def test_force_sync_total_symbols_unchanged(self):
+        stats = self.mgr.sync(force=True)
+        assert stats.total_symbols == 4
+
+
+# ---------------------------------------------------------------------------
+# Sync — progress callback
+# ---------------------------------------------------------------------------
+
+
+class TestSyncProgressCallback:
+    def setup_method(self):
+        self.mgr = _make_manager()
+
+    def test_progress_callback_called(self):
+        calls = []
+        self.mgr.sync(progress_callback=lambda cur, tot, name: calls.append((cur, tot, name)))
+        assert len(calls) > 0
+
+    def test_progress_callback_receives_library_names(self):
+        names = []
+        self.mgr.sync(progress_callback=lambda cur, tot, name: names.append(name))
+        # The final call has name='' (completion signal)
+        assert "TestDevice" in names or "TestPower" in names
+
+
+# ---------------------------------------------------------------------------
+# Search (after sync)
+# ---------------------------------------------------------------------------
+
+
+class TestSearchSymbols:
+    def setup_method(self):
+        self.mgr = _make_manager()
+        self.mgr.sync()
+
+    def test_search_resistor_finds_R(self):
+        results = self.mgr.search_symbols("Resistor")
+        assert any(r.symbol_name == "R" for r in results)
+
+    def test_search_capacitor_finds_C(self):
+        results = self.mgr.search_symbols("Capacitor")
+        assert any(r.symbol_name == "C" for r in results)
+
+    def test_search_power_finds_vcc_or_gnd(self):
+        results = self.mgr.search_symbols("power")
+        names = {r.symbol_name for r in results}
+        assert names & {"VCC", "GND"}
+
+    def test_search_no_match_returns_empty(self):
+        results = self.mgr.search_symbols("xyzzy_no_match_123")
+        assert results == []
+
+    def test_search_by_name_R(self):
+        results = self.mgr.search_by_name("R", exact=True)
+        assert len(results) == 1
+        assert results[0].symbol_name == "R"
+
+    def test_search_by_name_partial(self):
+        results = self.mgr.search_by_name("CC")
+        names = {r.symbol_name for r in results}
+        assert "VCC" in names
+
+
+# ---------------------------------------------------------------------------
+# get_symbol / get_library_symbols (after sync)
+# ---------------------------------------------------------------------------
+
+
+class TestLookupAfterSync:
+    def setup_method(self):
+        self.mgr = _make_manager()
+        self.mgr.sync()
+
+    def test_get_symbol_resistor(self):
+        sym = self.mgr.get_symbol("TestDevice", "R")
+        assert sym is not None
+        assert sym.description == "Resistor"
+        assert sym.pin_count == 2
+
+    def test_get_symbol_vcc(self):
+        sym = self.mgr.get_symbol("TestPower", "VCC")
+        assert sym is not None
+        assert sym.pin_count == 1
+
+    def test_get_symbol_not_found(self):
+        assert self.mgr.get_symbol("TestDevice", "NOEXIST") is None
+
+    def test_get_library_symbols_testdevice(self):
+        syms = self.mgr.get_library_symbols("TestDevice")
+        assert len(syms) == 2
+        names = {s.symbol_name for s in syms}
+        assert names == {"R", "C"}
+
+    def test_get_library_symbols_testpower(self):
+        syms = self.mgr.get_library_symbols("TestPower")
+        assert len(syms) == 2
+        names = {s.symbol_name for s in syms}
+        assert names == {"VCC", "GND"}
+
+    def test_get_all_libraries(self):
+        libs = self.mgr.get_all_libraries()
+        assert len(libs) == 2
+        names = {lib.library_name for lib in libs}
+        assert names == {"TestDevice", "TestPower"}

--- a/tests/unit/utils/test_symbol_index_reader.py
+++ b/tests/unit/utils/test_symbol_index_reader.py
@@ -1,0 +1,103 @@
+"""
+Tests for SymbolIndexReader — reads sym-lib-table and expands ${VAR} in URIs.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from kicad_mcp.config import LibraryPathConfig
+from kicad_mcp.utils.symbol_index_reader import SymbolIndexReader
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+class _FixtureConfig(LibraryPathConfig):
+    """LibraryPathConfig subclass that points to the test fixture directory."""
+
+    def __init__(self):
+        super().__init__()
+
+    @property
+    def symbol_table_file(self) -> str:
+        return str(FIXTURES_DIR / "sym-lib-table")
+
+    def get_env_vars(self) -> dict:
+        return {"KICAD_TEST_FIXTURES_DIR": str(FIXTURES_DIR)}
+
+
+class _MissingTableConfig(LibraryPathConfig):
+    """Config that points to a non-existent sym-lib-table."""
+
+    def __init__(self):
+        super().__init__()
+
+    @property
+    def symbol_table_file(self) -> str:
+        return "/nonexistent/path/sym-lib-table"
+
+    def get_env_vars(self) -> dict:
+        return {}
+
+
+class TestSymbolIndexReaderLibraries:
+    def setup_method(self):
+        self.reader = SymbolIndexReader(_FixtureConfig())
+
+    def test_returns_two_libraries(self):
+        libs = self.reader.get_libraries()
+        assert len(libs) == 2
+
+    def test_library_names(self):
+        libs = self.reader.get_libraries()
+        names = {lib.name for lib in libs}
+        assert "TestDevice" in names
+        assert "TestPower" in names
+
+    def test_library_types_are_kicad(self):
+        libs = self.reader.get_libraries()
+        for lib in libs:
+            assert lib.lib_type == "KiCad"
+
+    def test_env_var_expanded_in_uris(self):
+        libs = self.reader.get_libraries()
+        for lib in libs:
+            assert "${KICAD_TEST_FIXTURES_DIR}" not in lib.uri
+
+    def test_uris_point_to_fixture_dir(self):
+        libs = self.reader.get_libraries()
+        for lib in libs:
+            assert lib.uri.startswith(str(FIXTURES_DIR))
+
+    def test_uris_point_to_existing_files(self):
+        libs = self.reader.get_libraries()
+        for lib in libs:
+            assert Path(lib.uri).exists(), f"URI not found: {lib.uri}"
+
+    def test_library_descriptions_preserved(self):
+        libs = self.reader.get_libraries()
+        descs = {lib.descr for lib in libs}
+        assert "Test discrete components" in descs
+        assert "Test power symbols" in descs
+
+    def test_device_library_uri_ends_with_kicad_sym(self):
+        libs = self.reader.get_libraries()
+        device = next(lib for lib in libs if lib.name == "TestDevice")
+        assert device.uri.endswith("test_device.kicad_sym")
+
+    def test_power_library_uri_ends_with_kicad_sym(self):
+        libs = self.reader.get_libraries()
+        power = next(lib for lib in libs if lib.name == "TestPower")
+        assert power.uri.endswith("test_power.kicad_sym")
+
+
+class TestSymbolIndexReaderMissingTable:
+    def test_missing_table_raises_file_not_found(self):
+        reader = SymbolIndexReader(_MissingTableConfig())
+        with pytest.raises(FileNotFoundError):
+            reader.get_libraries()
+
+    def test_default_config_used_when_none_passed(self):
+        # SymbolIndexReader() with no args should construct without error.
+        reader = SymbolIndexReader()
+        assert reader is not None


### PR DESCRIPTION
## Summary

Adds a SQLite/FTS5-backed symbol library index with full-text search, enabling fast symbol lookups across all installed KiCad libraries without scanning files on every query.

## Changes

### New files
- `kicad_mcp/tools/symbol_tools.py` — 6 MCP tools for symbol search and index management
- `kicad_mcp/utils/symbol_database.py` — SQLAlchemy + SQLite/FTS5 database backend
- `kicad_mcp/utils/symbol_index_manager.py` — Background sync thread and index manager
- `kicad_mcp/utils/symbol_index_reader.py` — KiCad sym-lib-table path reader
- `tests/unit/tools/test_symbol_tools.py` — Unit tests for all symbol tools

### Modified files
- `kicad_mcp/server.py` — Register symbol tools
- `main.py` — Enable console logging for debugging
- `pyproject.toml` — Add kicad-skip dependency

### Removed files
- `kicad_mcp/tools/schematic_edit_tools.py` — Legacy file superseded by component_edit_tools.py

## Tools added

| Tool | Description |
|------|-------------|
| `sync_symbol_index` | Start background sync of symbol DB with KiCad libraries (non-blocking) |
| `get_symbol_sync_status` | Poll background sync progress |
| `search_symbols` | Full-text search by name, description, keywords |
| `get_symbol` | Look up a single symbol by library:name |
| `list_symbol_libraries` | List all indexed libraries |
| `get_library_symbols` | List all symbols in a library |
| `get_symbol_index_stats` | DB statistics (counts, last sync, path) |

## Testing
14 unit tests covering all tools using mock SymbolIndexManager.