### PR TITLE
refactor(netlist): Use skip to extract netlist information. Merge extract and analyze tools into extract_schematic_netlist

### DIFF
--- a/kicad_mcp/tools/netlist_tools.py
+++ b/kicad_mcp/tools/netlist_tools.py
@@ -2,11 +2,12 @@
 Netlist extraction and analysis tools for KiCad schematics.
 """
 import os
+import re
 from typing import Dict, Any
-from mcp.server.fastmcp import FastMCP, Context
+from fastmcp import FastMCP, Context
 
 from kicad_mcp.utils.file_utils import get_project_files
-from kicad_mcp.utils.netlist_parser import extract_netlist, analyze_netlist
+from kicad_mcp.utils.netlist_parser import extract_netlist
 
 def register_netlist_tools(mcp: FastMCP) -> None:
     """Register netlist-related tools with the MCP server.
@@ -15,85 +16,6 @@ def register_netlist_tools(mcp: FastMCP) -> None:
         mcp: The FastMCP server instance
     """
     
-    @mcp.tool()
-    async def extract_schematic_netlist(schematic_path: str, ctx: Context | None) -> Dict[str, Any]:
-        """Extract netlist information from a KiCad schematic.
-        
-        This tool parses a KiCad schematic file and extracts comprehensive
-        netlist information including components, connections, and labels.
-        
-        Args:
-            schematic_path: Path to the KiCad schematic file (.kicad_sch)
-            ctx: MCP context for progress reporting
-            
-        Returns:
-            Dictionary with netlist information
-        """
-        print(f"Extracting netlist from schematic: {schematic_path}")
-        
-        if not os.path.exists(schematic_path):
-            print(f"Schematic file not found: {schematic_path}")
-            if ctx:
-                ctx.info(f"Schematic file not found: {schematic_path}")
-            return {"success": False, "error": f"Schematic file not found: {schematic_path}"}
-        
-        # Report progress
-        if ctx:
-            await ctx.report_progress(10, 100)
-            ctx.info(f"Loading schematic file: {os.path.basename(schematic_path)}")
-        
-        # Extract netlist information
-        try:
-            if ctx:
-                await ctx.report_progress(20, 100)
-                ctx.info("Parsing schematic structure...")
-            
-            netlist_data = extract_netlist(schematic_path)
-            
-            if "error" in netlist_data:
-                print(f"Error extracting netlist: {netlist_data['error']}")
-                if ctx:
-                    ctx.info(f"Error extracting netlist: {netlist_data['error']}")
-                return {"success": False, "error": netlist_data['error']}
-            
-            if ctx:
-                await ctx.report_progress(60, 100)
-                ctx.info(f"Extracted {netlist_data['component_count']} components and {netlist_data['net_count']} nets")
-            
-            # Analyze the netlist
-            if ctx:
-                await ctx.report_progress(70, 100)
-                ctx.info("Analyzing netlist data...")
-            
-            analysis_results = analyze_netlist(netlist_data)
-            
-            if ctx:
-                await ctx.report_progress(90, 100)
-            
-            # Build result
-            result = {
-                "success": True,
-                "schematic_path": schematic_path,
-                "component_count": netlist_data["component_count"],
-                "net_count": netlist_data["net_count"],
-                "components": netlist_data["components"],
-                "nets": netlist_data["nets"],
-                "analysis": analysis_results
-            }
-            
-            # Complete progress
-            if ctx:
-                await ctx.report_progress(100, 100)
-                ctx.info("Netlist extraction complete")
-            
-            return result
-            
-        except Exception as e:
-            print(f"Error extracting netlist: {str(e)}")
-            if ctx:
-                ctx.info(f"Error extracting netlist: {str(e)}")
-            return {"success": False, "error": str(e)}
-
     @mcp.tool()
     async def extract_project_netlist(project_path: str, ctx: Context | None) -> Dict[str, Any]:
         """Extract netlist from a KiCad project's schematic.
@@ -140,7 +62,7 @@ def register_netlist_tools(mcp: FastMCP) -> None:
                 await ctx.report_progress(20, 100)
             
             # Call the schematic netlist extraction
-            result = await extract_schematic_netlist(schematic_path, ctx)
+            result = await extract_schematic_netlist(schematic_path, ctx=ctx)
             
             # Add project path to result
             if "success" in result and result["success"]:
@@ -155,20 +77,76 @@ def register_netlist_tools(mcp: FastMCP) -> None:
             return {"success": False, "error": str(e)}
 
     @mcp.tool()
-    async def analyze_schematic_connections(schematic_path: str, ctx: Context | None) -> Dict[str, Any]:
-        """Analyze connections in a KiCad schematic.
-        
-        This tool provides detailed analysis of component connections,
-        including power nets, signal paths, and potential issues.
-        
+    async def extract_schematic_netlist(
+        schematic_path: str,
+        include_wire_topology: bool = False,
+        ctx: Context | None = None,
+    ) -> Dict[str, Any]:
+        """Extract component inventory, net analysis, and wire geometry() for a KiCad schematic.
+
+        A net is a named group of pins that are electrically connected by wires.
+        For example, if R1/pin2, C1/pin1, and a GND power symbol are all joined
+        by wires, they form one net named "GND".
+
+        Returns the full component list (with positions and pin coordinates), net
+        classification (power vs signal), component type counts, and simple issue
+        detection. Pin coordinates are included in the component list; net entries
+        contain only component references and pin numbers to avoid duplication.
+
+        Set ``include_wire_topology=True`` to also receive a top-level ``wires``
+        dict keyed by wire ID. Each wire entry includes its net name (``null``
+        if unconnected), start/end mm coordinates, and which component pins touch
+        each endpoint.
+
         Args:
             schematic_path: Path to the KiCad schematic file (.kicad_sch)
+            include_wire_topology: When True, a top-level ``wires`` dict is
+                added to the analysis. Each wire carries its own ``net`` field
+                (the net name, or null if the wire is unconnected). Default True.
             ctx: MCP context for progress reporting
-            
+
         Returns:
-            Dictionary with connection analysis
+            Dictionary with the following structure on success:
+            {
+                "success": True,
+                "schematic_path": "<path>",
+                "analysis": {
+                    "component_count": <int>,
+                    "net_count": <int>,
+                    "component_types": {"R": 3, "C": 2, ...},
+                    "components": {
+                        "R1": {"value": "10k",
+                               "position": {"x": ..., "y": ...},
+                               "pins": [{"num": "1", "x": ..., "y": ..., "net": "GND"}, ...]},
+                        ...
+                    },
+                    "power_nets": [
+                        {
+                            "name": "GND",
+                            "pin_count": <int>
+                        },
+                        ...
+                    ],
+                    "signal_nets": [ <same structure as power_nets> ],
+                    "floating_nets": [
+                        {
+                            "net": "<net name>",
+                            "description": "<explanation>"
+                        }, ...
+                    ],
+                    # if include_wire_topology=True:
+                    "wires": {
+                        "0": {"net": "GND", "start": {"x": ..., "y": ...}, "end": {"x": ..., "y": ...},
+                              "start_pins": [{"ref": "R1", "pin": "1"}], "end_pins": []},
+                        "5": {"net": null, "start": {"x": ..., "y": ...}, "end": {"x": ..., "y": ...},
+                              "start_pins": [], "end_pins": []},
+                        ...
+                    }
+                }
+            }
+            On failure: {"success": False, "error": "<error message>"}
         """
-        print(f"Analyzing connections in schematic: {schematic_path}")
+        print(f"Extracting netlist from schematic: {schematic_path}")
         
         if not os.path.exists(schematic_path):
             print(f"Schematic file not found: {schematic_path}")
@@ -198,63 +176,106 @@ def register_netlist_tools(mcp: FastMCP) -> None:
             if ctx:
                 ctx.info("Performing connection analysis...")
             
+            raw_components = netlist_data.get("components", {})
+
+            # Build pin→net lookup so each pin entry can carry its net name
+            _raw_nets = netlist_data.get("nets", {})
+            pin_to_net: Dict[tuple, str] = {}
+            for _net_name, _net_pins in _raw_nets.items():
+                for _p in _net_pins:
+                    pin_to_net[(_p.get("component", ""), str(_p.get("pin", "")))] = _net_name
+
+            components = {
+                ref: {
+                    "value": cdata.get("value", ""),
+                    "position": cdata.get("position", {}),
+                    "pins": [
+                        {**pinfo, "net": pin_to_net.get((ref, str(pinfo.get("num", ""))), None)}
+                        for pinfo in cdata.get("pins", [])
+                    ],
+                }
+                for ref, cdata in raw_components.items()
+            }
             analysis = {
                 "component_count": netlist_data["component_count"],
                 "net_count": netlist_data["net_count"],
                 "component_types": {},
+                "components": components,
                 "power_nets": [],
                 "signal_nets": [],
-                "potential_issues": []
+                "floating_nets": []
             }
             
             # Analyze component types
-            components = netlist_data.get("components", {})
-            for ref, component in components.items():
-                # Extract component type from reference (e.g., R1 -> R)
-                import re
+            for ref in components:
                 comp_type_match = re.match(r'^([A-Za-z_]+)', ref)
                 if comp_type_match:
                     comp_type = comp_type_match.group(1)
-                    if comp_type not in analysis["component_types"]:
-                        analysis["component_types"][comp_type] = 0
-                    analysis["component_types"][comp_type] += 1
+                    analysis["component_types"][comp_type] = analysis["component_types"].get(comp_type, 0) + 1
             
             if ctx:
                 await ctx.report_progress(60, 100)
-            
-            # Identify power nets
+
+            # Classify nets and detect floating ones in a single pass
+            _POWER_PREFIXES = ("VCC", "VDD", "GND", "+5V", "+3V3", "+12V")
             nets = netlist_data.get("nets", {})
             for net_name, pins in nets.items():
-                if any(net_name.startswith(prefix) for prefix in ["VCC", "VDD", "GND", "+5V", "+3V3", "+12V"]):
-                    analysis["power_nets"].append({
-                        "name": net_name,
-                        "pin_count": len(pins)
-                    })
+                is_power = any(net_name.startswith(pfx) for pfx in _POWER_PREFIXES)
+                net_entry = {
+                    "name": net_name,
+                    "pin_count": len(pins),
+                }
+                if is_power:
+                    analysis["power_nets"].append(net_entry)
                 else:
-                    analysis["signal_nets"].append({
-                        "name": net_name,
-                        "pin_count": len(pins)
-                    })
-            
+                    analysis["signal_nets"].append(net_entry)
+                    if len(pins) <= 1:
+                        analysis["floating_nets"].append({
+                            "net": net_name,
+                            "description": f"Net '{net_name}' appears to be floating (only has {len(pins)} connection)"
+                        })
+
             if ctx:
                 await ctx.report_progress(80, 100)
-            
-            # Check for potential issues
-            # 1. Nets with only one connection (floating)
-            for net_name, pins in nets.items():
-                if len(pins) <= 1 and not any(net_name.startswith(prefix) for prefix in ["VCC", "VDD", "GND", "+5V", "+3V3", "+12V"]):
-                    analysis["potential_issues"].append({
-                        "type": "floating_net",
-                        "net": net_name,
-                        "description": f"Net '{net_name}' appears to be floating (only has {len(pins)} connection)"
-                    })
-            
-            # 2. Power pins without connections
-            # This would require more detailed parsing of the schematic
-            
+
+            if include_wire_topology:
+                ROUND = 4
+
+                def rpt(x, y):
+                    return (round(float(x), ROUND), round(float(y), ROUND))
+
+                # Reuse the wire→net mapping already resolved by the parser
+                point_to_net = netlist_data.get("point_to_net", {})
+
+                # Build point → component-pins lookup from component pin world coords
+                from collections import defaultdict as _dd
+                pin_at: Dict[Any, list] = _dd(list)
+                for ref, cdata in components.items():
+                    for pinfo in cdata.get("pins", []):
+                        pin_at[rpt(pinfo["x"], pinfo["y"])].append(
+                            {"ref": ref, "pin": str(pinfo.get("num", ""))}
+                        )
+
+                # Build global wire registry
+                all_wires = netlist_data.get("wires", [])
+                wires: Dict[str, Any] = {}
+                for wire_id, wdata in enumerate(all_wires):
+                    sp = rpt(wdata["start"]["x"], wdata["start"]["y"])
+                    ep = rpt(wdata["end"]["x"],   wdata["end"]["y"])
+                    wnet = point_to_net.get(sp) or point_to_net.get(ep)
+                    wires[str(wire_id)] = {
+                        "net":        wnet,
+                        "start":      wdata["start"],
+                        "end":        wdata["end"],
+                        "start_pins": list(pin_at.get(sp, [])),
+                        "end_pins":   list(pin_at.get(ep, [])),
+                    }
+
+                analysis["wires"] = wires
+
             if ctx:
                 await ctx.report_progress(90, 100)
-            
+
             # Build result
             result = {
                 "success": True,
@@ -265,14 +286,14 @@ def register_netlist_tools(mcp: FastMCP) -> None:
             # Complete progress
             if ctx:
                 await ctx.report_progress(100, 100)
-                ctx.info("Connection analysis complete")
+                ctx.info("Netlist extraction complete")
             
             return result
             
         except Exception as e:
-            print(f"Error analyzing connections: {str(e)}")
+            print(f"Error extracting netlist: {str(e)}")
             if ctx:
-                ctx.info(f"Error analyzing connections: {str(e)}")
+                ctx.info(f"Error extracting netlist: {str(e)}")
             return {"success": False, "error": str(e)}
 
     @mcp.tool()

--- a/kicad_mcp/tools/netlist_tools.py
+++ b/kicad_mcp/tools/netlist_tools.py
@@ -136,10 +136,12 @@ def register_netlist_tools(mcp: FastMCP) -> None:
                     ],
                     # if include_wire_topology=True:
                     "wires": {
-                        "0": {"net": "GND", "start": {"x": ..., "y": ...}, "end": {"x": ..., "y": ...},
-                              "start_pins": [{"ref": "R1", "pin": "1"}], "end_pins": []},
-                        "5": {"net": null, "start": {"x": ..., "y": ...}, "end": {"x": ..., "y": ...},
-                              "start_pins": [], "end_pins": []},
+                        "0": {"net": "GND",
+                              "start": {"x": ..., "y": ..., "pins": [{"ref": "R1", "pin": "1"}]},
+                              "end":   {"x": ..., "y": ..., "pins": []}},
+                        "5": {"net": null,
+                              "start": {"x": ..., "y": ..., "pins": []},
+                              "end":   {"x": ..., "y": ..., "pins": []}},
                         ...
                     }
                 }
@@ -264,11 +266,9 @@ def register_netlist_tools(mcp: FastMCP) -> None:
                     ep = rpt(wdata["end"]["x"],   wdata["end"]["y"])
                     wnet = point_to_net.get(sp) or point_to_net.get(ep)
                     wires[str(wire_id)] = {
-                        "net":        wnet,
-                        "start":      wdata["start"],
-                        "end":        wdata["end"],
-                        "start_pins": list(pin_at.get(sp, [])),
-                        "end_pins":   list(pin_at.get(ep, [])),
+                        "net":   wnet,
+                        "start": {**wdata["start"], "pins": list(pin_at.get(sp, []))},
+                        "end":   {**wdata["end"],   "pins": list(pin_at.get(ep, []))},
                     }
 
                 analysis["wires"] = wires

--- a/kicad_mcp/utils/netlist_parser.py
+++ b/kicad_mcp/utils/netlist_parser.py
@@ -8,6 +8,8 @@ from collections import defaultdict
 
 import skip
 
+from kicad_mcp.utils.skip_helpers import sym_pin_world_coords
+
 
 class SchematicParser:
     """Parser for KiCad schematic files to extract netlist information."""
@@ -129,49 +131,11 @@ class SchematicParser:
             except (AttributeError, IndexError, TypeError):
                 pass
 
-            # Pins: pin.location gives world coords (rotation-corrected by skip)
+            # Collect pin positions via shared helper (handles the skip bug
+            # for single-pin symbols: power nets, PWR_FLAG, TestPoint, etc.)
             pins_summary: List[Dict[str, str]] = []
-            try:
-                for pin in sym.pin:
-                    try:
-                        num = str(pin.number)
-                        loc = pin.location
-                        pins_summary.append({'num': num, 'x': float(loc.x), 'y': float(loc.y)})
-                    except AttributeError:
-                        continue
-            except (AttributeError, TypeError):
-                pass
-
-            # Fallback for a skip library bug: single-pin symbols (e.g. TestPoint)
-            # cause sym.pin to raise AttributeError internally, making Python fall
-            # back via __getattr__ to the raw ParsedValue.  Iterating it yields the
-            # pin's children ("1", uuid) rather than SymbolPin objects, so every
-            # pin.number access fails silently and pins_summary stays empty.
-            # Compute world positions directly from lib_symbol + placement instead.
-            if not pins_summary:
-                try:
-                    from skip.at_location import AtValue as _AtValue
-                    import copy as _copy
-                    lib_sym = sym.lib_symbol
-                    if lib_sym is not None:
-                        sym_at = _AtValue(sym.at.value)
-                        for lib_pin in lib_sym.pin:
-                            try:
-                                num = str(lib_pin.number.value)
-                                rel_raw = _copy.deepcopy(lib_pin.at.value)
-                                rel_at = _AtValue(rel_raw)
-                                manip_at = _AtValue(_copy.deepcopy(rel_raw))
-                                manip_at.rotation = 0
-                                while manip_at.rotation != sym_at.rotation:
-                                    manip_at.rotate90degrees()
-                                    rel_at.rotate90degrees()
-                                wx = round(sym_at.x + rel_at.x, 4)
-                                wy = round(sym_at.y - rel_at.y, 4)
-                                pins_summary.append({'num': num, 'x': wx, 'y': wy})
-                            except Exception:
-                                continue
-                except Exception:
-                    pass
+            for pin in sym_pin_world_coords(sym):
+                pins_summary.append({'num': pin.number, 'x': str(pin.x), 'y': str(pin.y)})
 
             if pins_summary:
                 comp['pins'] = pins_summary

--- a/kicad_mcp/utils/netlist_parser.py
+++ b/kicad_mcp/utils/netlist_parser.py
@@ -3,49 +3,50 @@ KiCad schematic netlist extraction utilities.
 """
 import os
 import re
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
 from collections import defaultdict
+
+import skip
+
 
 class SchematicParser:
     """Parser for KiCad schematic files to extract netlist information."""
-    
+
     def __init__(self, schematic_path: str):
         """Initialize the schematic parser.
-        
+
         Args:
             schematic_path: Path to the KiCad schematic file (.kicad_sch)
         """
         self.schematic_path = schematic_path
-        self.content = ""
-        self.components = []
-        self.labels = []
-        self.wires = []
-        self.junctions = []
-        self.no_connects = []
-        self.power_symbols = []
-        self.hierarchical_labels = []
-        self.global_labels = []
-        
+        self._sch = None
+        self.components: List[Dict[str, Any]] = []
+        self.labels: List[Dict[str, Any]] = []
+        self.wires: List[Dict[str, Any]] = []
+        self.junctions: List[Dict[str, Any]] = []
+        self.no_connects: List[Dict[str, Any]] = []
+        self.power_symbols: List[Dict[str, Any]] = []
+        self.hierarchical_labels: List[Dict[str, Any]] = []
+        self.global_labels: List[Dict[str, Any]] = []
+
         # Netlist information
-        self.nets = defaultdict(list)  # Net name -> connected pins
-        self.component_pins = {}  # (component_ref, pin_num) -> net_name
-        
+        self.nets: Dict[str, List] = defaultdict(list)
+        self.component_pins: Dict[Tuple, str] = {}
+        self.point_to_net: Dict[Tuple, str] = {}
+
         # Component information
-        self.component_info = {}  # component_ref -> component details
-        
-        # Load the file
+        self.component_info: Dict[str, Dict[str, Any]] = {}
+
         self._load_schematic()
 
     def _load_schematic(self) -> None:
-        """Load the schematic file content."""
+        """Load the schematic using the skip library."""
         if not os.path.exists(self.schematic_path):
             print(f"Schematic file not found: {self.schematic_path}")
             raise FileNotFoundError(f"Schematic file not found: {self.schematic_path}")
-        
         try:
-            with open(self.schematic_path, 'r') as f:
-                self.content = f.read()
-                print(f"Successfully loaded schematic: {self.schematic_path}")
+            self._sch = skip.Schematic(self.schematic_path)
+            print(f"Successfully loaded schematic: {self.schematic_path}")
         except Exception as e:
             print(f"Error reading schematic file: {str(e)}")
             raise
@@ -57,29 +58,15 @@ class SchematicParser:
             Dictionary with parsed netlist information
         """
         print("Starting schematic parsing")
-        
-        # Extract symbols (components)
+
         self._extract_components()
-        
-        # Extract wires
         self._extract_wires()
-        
-        # Extract junctions
         self._extract_junctions()
-        
-        # Extract labels
         self._extract_labels()
-        
-        # Extract power symbols
         self._extract_power_symbols()
-        
-        # Extract no-connects
         self._extract_no_connects()
-        
-        # Build netlist
         self._build_netlist()
-        
-        # Create result
+
         result = {
             "components": self.component_info,
             "nets": dict(self.nets),
@@ -88,314 +75,367 @@ class SchematicParser:
             "junctions": self.junctions,
             "power_symbols": self.power_symbols,
             "component_count": len(self.component_info),
-            "net_count": len(self.nets)
+            "net_count": len(self.nets),
+            "point_to_net": self.point_to_net,
         }
-        
+
         print(f"Schematic parsing complete: found {len(self.component_info)} components and {len(self.nets)} nets")
         return result
-
-    def _extract_s_expressions(self, pattern: str) -> List[str]:
-        """Extract all matching S-expressions from the schematic content.
-        
-        Args:
-            pattern: Regex pattern to match the start of S-expressions
-            
-        Returns:
-            List of matching S-expressions
-        """
-        matches = []
-        positions = []
-        
-        # Find all starting positions of matches
-        for match in re.finditer(pattern, self.content):
-            positions.append(match.start())
-        
-        # Extract full S-expressions for each match
-        for pos in positions:
-            # Start from the matching position
-            current_pos = pos
-            depth = 0
-            s_exp = ""
-            
-            # Extract the full S-expression by tracking parentheses
-            while current_pos < len(self.content):
-                char = self.content[current_pos]
-                s_exp += char
-                
-                if char == '(':
-                    depth += 1
-                elif char == ')':
-                    depth -= 1
-                    if depth == 0:
-                        # Found the end of the S-expression
-                        break
-                
-                current_pos += 1
-            
-            matches.append(s_exp)
-        
-        return matches
 
     def _extract_components(self) -> None:
         """Extract component information from schematic."""
         print("Extracting components")
-        
-        # Extract all symbol expressions (components)
-        symbols = self._extract_s_expressions(r'\(symbol\s+')
-        
-        for symbol in symbols:
-            component = self._parse_component(symbol)
-            if component:
-                self.components.append(component)
-                
-                # Add to component info dictionary
-                ref = component.get('reference', 'Unknown')
-                self.component_info[ref] = component
-        
-        print(f"Extracted {len(self.components)} components")
+        try:
+            symbols = self._sch.symbol
+        except AttributeError:
+            print("No symbols found in schematic")
+            return
 
-    def _parse_component(self, symbol_expr: str) -> Dict[str, Any]:
-        """Parse a component from a symbol S-expression.
-        
-        Args:
-            symbol_expr: Symbol S-expression
-            
-        Returns:
-            Component information dictionary
-        """
-        component = {}
-        
-        # Extract library component ID
-        lib_id_match = re.search(r'\(lib_id\s+"([^"]+)"\)', symbol_expr)
-        if lib_id_match:
-            component['lib_id'] = lib_id_match.group(1)
-        
-        # Extract reference (e.g., R1, C2)
-        property_matches = re.finditer(r'\(property\s+"([^"]+)"\s+"([^"]+)"', symbol_expr)
-        for match in property_matches:
-            prop_name = match.group(1)
-            prop_value = match.group(2)
-            
-            if prop_name == "Reference":
-                component['reference'] = prop_value
-            elif prop_name == "Value":
-                component['value'] = prop_value
-            elif prop_name == "Footprint":
-                component['footprint'] = prop_value
-            else:
-                # Store other properties
-                if 'properties' not in component:
-                    component['properties'] = {}
-                component['properties'][prop_name] = prop_value
-        
-        # Extract position
-        pos_match = re.search(r'\(at\s+([\d\.-]+)\s+([\d\.-]+)(\s+[\d\.-]+)?\)', symbol_expr)
-        if pos_match:
-            component['position'] = {
-                'x': float(pos_match.group(1)),
-                'y': float(pos_match.group(2)),
-                'angle': float(pos_match.group(3).strip() if pos_match.group(3) else 0)
-            }
-        
-        # Extract pins
-        pins = []
-        pin_matches = re.finditer(r'\(pin\s+\(num\s+"([^"]+)"\)\s+\(name\s+"([^"]+)"\)', symbol_expr)
-        for match in pin_matches:
-            pin_num = match.group(1)
-            pin_name = match.group(2)
-            pins.append({
-                'num': pin_num,
-                'name': pin_name
-            })
-        
-        if pins:
-            component['pins'] = pins
-        
-        return component
+        for sym in symbols:
+            comp: Dict[str, Any] = {}
+
+            # Reference is required; skip entries that don't have one
+            try:
+                comp['reference'] = sym.property.Reference.value
+            except AttributeError:
+                continue
+            ref = comp['reference']
+            if not ref:
+                continue
+
+            try:
+                comp['lib_id'] = sym.lib_id.value
+            except AttributeError:
+                pass
+
+            try:
+                comp['value'] = sym.property.Value.value
+            except AttributeError:
+                pass
+
+            try:
+                comp['footprint'] = sym.property.Footprint.value
+            except AttributeError:
+                pass
+
+            # sym.at.value -> [x, y, angle]
+            try:
+                at_val = sym.at.value
+                comp['position'] = {
+                    'x': float(at_val[0]),
+                    'y': float(at_val[1]),
+                    'angle': float(at_val[2]) if len(at_val) > 2 else 0.0,
+                }
+            except (AttributeError, IndexError, TypeError):
+                pass
+
+            # Pins: pin.location gives world coords (rotation-corrected by skip)
+            pins_summary: List[Dict[str, str]] = []
+            try:
+                for pin in sym.pin:
+                    try:
+                        num = str(pin.number)
+                        loc = pin.location
+                        pins_summary.append({'num': num, 'x': float(loc.x), 'y': float(loc.y)})
+                    except AttributeError:
+                        continue
+            except (AttributeError, TypeError):
+                pass
+
+            # Fallback for a skip library bug: single-pin symbols (e.g. TestPoint)
+            # cause sym.pin to raise AttributeError internally, making Python fall
+            # back via __getattr__ to the raw ParsedValue.  Iterating it yields the
+            # pin's children ("1", uuid) rather than SymbolPin objects, so every
+            # pin.number access fails silently and pins_summary stays empty.
+            # Compute world positions directly from lib_symbol + placement instead.
+            if not pins_summary:
+                try:
+                    from skip.at_location import AtValue as _AtValue
+                    import copy as _copy
+                    lib_sym = sym.lib_symbol
+                    if lib_sym is not None:
+                        sym_at = _AtValue(sym.at.value)
+                        for lib_pin in lib_sym.pin:
+                            try:
+                                num = str(lib_pin.number.value)
+                                rel_raw = _copy.deepcopy(lib_pin.at.value)
+                                rel_at = _AtValue(rel_raw)
+                                manip_at = _AtValue(_copy.deepcopy(rel_raw))
+                                manip_at.rotation = 0
+                                while manip_at.rotation != sym_at.rotation:
+                                    manip_at.rotate90degrees()
+                                    rel_at.rotate90degrees()
+                                wx = round(sym_at.x + rel_at.x, 4)
+                                wy = round(sym_at.y - rel_at.y, 4)
+                                pins_summary.append({'num': num, 'x': wx, 'y': wy})
+                            except Exception:
+                                continue
+                except Exception:
+                    pass
+
+            if pins_summary:
+                comp['pins'] = pins_summary
+
+            self.components.append(comp)
+            self.component_info[ref] = comp
+
+        print(f"Extracted {len(self.components)} components")
 
     def _extract_wires(self) -> None:
         """Extract wire information from schematic."""
         print("Extracting wires")
-        
-        # Extract all wire expressions
-        wires = self._extract_s_expressions(r'\(wire\s+')
-        
-        for wire in wires:
-            # Extract the wire coordinates
-            pts_match = re.search(r'\(pts\s+\(xy\s+([\d\.-]+)\s+([\d\.-]+)\)\s+\(xy\s+([\d\.-]+)\s+([\d\.-]+)\)\)', wire)
-            if pts_match:
-                self.wires.append({
-                    'start': {
-                        'x': float(pts_match.group(1)),
-                        'y': float(pts_match.group(2))
-                    },
-                    'end': {
-                        'x': float(pts_match.group(3)),
-                        'y': float(pts_match.group(4))
-                    }
-                })
-        
+        try:
+            for wire in self._sch.wire:
+                try:
+                    xys = wire.pts.xy
+                    s, e = xys[0].value, xys[1].value
+                    self.wires.append({
+                        'start': {'x': float(s[0]), 'y': float(s[1])},
+                        'end':   {'x': float(e[0]), 'y': float(e[1])},
+                    })
+                except (AttributeError, IndexError, TypeError):
+                    continue
+        except AttributeError:
+            pass
         print(f"Extracted {len(self.wires)} wires")
 
     def _extract_junctions(self) -> None:
         """Extract junction information from schematic."""
         print("Extracting junctions")
-        
-        # Extract all junction expressions
-        junctions = self._extract_s_expressions(r'\(junction\s+')
-        
-        for junction in junctions:
-            # Extract the junction coordinates
-            xy_match = re.search(r'\(junction\s+\(xy\s+([\d\.-]+)\s+([\d\.-]+)\)\)', junction)
-            if xy_match:
-                self.junctions.append({
-                    'x': float(xy_match.group(1)),
-                    'y': float(xy_match.group(2))
-                })
-        
+        try:
+            for junc in self._sch.junction._elements:
+                try:
+                    at_val = junc.at.value
+                    self.junctions.append({
+                        'x': float(at_val[0]),
+                        'y': float(at_val[1]),
+                    })
+                except (AttributeError, IndexError, TypeError):
+                    continue
+        except AttributeError:
+            pass
         print(f"Extracted {len(self.junctions)} junctions")
 
     def _extract_labels(self) -> None:
         """Extract label information from schematic."""
         print("Extracting labels")
-        
-        # Extract local labels
-        local_labels = self._extract_s_expressions(r'\(label\s+')
-        
-        for label in local_labels:
-            # Extract label text and position
-            label_match = re.search(r'\(label\s+"([^"]+)"\s+\(at\s+([\d\.-]+)\s+([\d\.-]+)(\s+[\d\.-]+)?\)', label)
-            if label_match:
-                self.labels.append({
-                    'type': 'local',
-                    'text': label_match.group(1),
-                    'position': {
-                        'x': float(label_match.group(2)),
-                        'y': float(label_match.group(3)),
-                        'angle': float(label_match.group(4).strip() if label_match.group(4) else 0)
-                    }
-                })
-        
-        # Extract global labels
-        global_labels = self._extract_s_expressions(r'\(global_label\s+')
-        
-        for label in global_labels:
-            # Extract global label text and position
-            label_match = re.search(r'\(global_label\s+"([^"]+)"\s+\(shape\s+([^\s\)]+)\)\s+\(at\s+([\d\.-]+)\s+([\d\.-]+)(\s+[\d\.-]+)?\)', label)
-            if label_match:
-                self.global_labels.append({
-                    'type': 'global',
-                    'text': label_match.group(1),
-                    'shape': label_match.group(2),
-                    'position': {
-                        'x': float(label_match.group(3)),
-                        'y': float(label_match.group(4)),
-                        'angle': float(label_match.group(5).strip() if label_match.group(5) else 0)
-                    }
-                })
-        
-        # Extract hierarchical labels
-        hierarchical_labels = self._extract_s_expressions(r'\(hierarchical_label\s+')
-        
-        for label in hierarchical_labels:
-            # Extract hierarchical label text and position
-            label_match = re.search(r'\(hierarchical_label\s+"([^"]+)"\s+\(shape\s+([^\s\)]+)\)\s+\(at\s+([\d\.-]+)\s+([\d\.-]+)(\s+[\d\.-]+)?\)', label)
-            if label_match:
-                self.hierarchical_labels.append({
-                    'type': 'hierarchical',
-                    'text': label_match.group(1),
-                    'shape': label_match.group(2),
-                    'position': {
-                        'x': float(label_match.group(3)),
-                        'y': float(label_match.group(4)),
-                        'angle': float(label_match.group(5).strip() if label_match.group(5) else 0)
-                    }
-                })
-        
-        print(f"Extracted {len(self.labels)} local labels, {len(self.global_labels)} global labels, and {len(self.hierarchical_labels)} hierarchical labels")
+
+        # Local labels: (label "NAME" (at x y angle) ...)
+        try:
+            for label in self._sch.label._elements:
+                try:
+                    at_val = label.at.value
+                    self.labels.append({
+                        'type': 'local',
+                        'text': str(label.value),
+                        'position': {
+                            'x': float(at_val[0]),
+                            'y': float(at_val[1]),
+                            'angle': float(at_val[2]) if len(at_val) > 2 else 0.0,
+                        },
+                    })
+                except (AttributeError, IndexError, TypeError):
+                    continue
+        except AttributeError:
+            pass
+
+        # Global labels
+        try:
+            for label in self._sch.global_label._elements:
+                try:
+                    at_val = label.at.value
+                    self.global_labels.append({
+                        'type': 'global',
+                        'text': str(label.value),
+                        'position': {
+                            'x': float(at_val[0]),
+                            'y': float(at_val[1]),
+                            'angle': float(at_val[2]) if len(at_val) > 2 else 0.0,
+                        },
+                    })
+                except (AttributeError, IndexError, TypeError):
+                    continue
+        except AttributeError:
+            pass
+
+        # Hierarchical labels
+        try:
+            hl_coll = self._sch.hierarchical_label
+            if hl_coll is not None:
+                for label in hl_coll._elements:
+                    try:
+                        at_val = label.at.value
+                        self.hierarchical_labels.append({
+                            'type': 'hierarchical',
+                            'text': str(label.value),
+                            'position': {
+                                'x': float(at_val[0]),
+                                'y': float(at_val[1]),
+                                'angle': float(at_val[2]) if len(at_val) > 2 else 0.0,
+                            },
+                        })
+                    except (AttributeError, IndexError, TypeError):
+                        continue
+        except AttributeError:
+            pass
+
+        print(f"Extracted {len(self.labels)} local labels, "
+              f"{len(self.global_labels)} global labels, "
+              f"and {len(self.hierarchical_labels)} hierarchical labels")
 
     def _extract_power_symbols(self) -> None:
         """Extract power symbol information from schematic."""
         print("Extracting power symbols")
-        
-        # Extract all power symbol expressions
-        power_symbols = self._extract_s_expressions(r'\(symbol\s+\(lib_id\s+"power:')
-        
-        for symbol in power_symbols:
-            # Extract power symbol type and position
-            type_match = re.search(r'\(lib_id\s+"power:([^"]+)"\)', symbol)
-            pos_match = re.search(r'\(at\s+([\d\.-]+)\s+([\d\.-]+)(\s+[\d\.-]+)?\)', symbol)
-            
-            if type_match and pos_match:
+        for comp in self.components:
+            if comp.get('lib_id', '').startswith('power:'):
                 self.power_symbols.append({
-                    'type': type_match.group(1),
-                    'position': {
-                        'x': float(pos_match.group(1)),
-                        'y': float(pos_match.group(2)),
-                        'angle': float(pos_match.group(3).strip() if pos_match.group(3) else 0)
-                    }
+                    'type': comp['lib_id'].split(':', 1)[1],
+                    'position': comp.get('position', {}),
                 })
-        
         print(f"Extracted {len(self.power_symbols)} power symbols")
 
     def _extract_no_connects(self) -> None:
         """Extract no-connect information from schematic."""
         print("Extracting no-connects")
-        
-        # Extract all no-connect expressions
-        no_connects = self._extract_s_expressions(r'\(no_connect\s+')
-        
-        for no_connect in no_connects:
-            # Extract the no-connect coordinates
-            xy_match = re.search(r'\(no_connect\s+\(at\s+([\d\.-]+)\s+([\d\.-]+)\)', no_connect)
-            if xy_match:
-                self.no_connects.append({
-                    'x': float(xy_match.group(1)),
-                    'y': float(xy_match.group(2))
-                })
-        
+        try:
+            nc_coll = self._sch.no_connect
+            if nc_coll is not None:
+                for nc in nc_coll._elements:
+                    try:
+                        at_val = nc.at.value
+                        self.no_connects.append({
+                            'x': float(at_val[0]),
+                            'y': float(at_val[1]),
+                        })
+                    except (AttributeError, IndexError, TypeError):
+                        continue
+        except AttributeError:
+            pass
         print(f"Extracted {len(self.no_connects)} no-connects")
 
     def _build_netlist(self) -> None:
-        """Build the netlist from extracted components and connections."""
+        """Build the netlist by tracing wire connectivity between component pins.
+
+        Uses skip's pin.location (world coordinates, rotation already applied)
+        together with a union-find over wire endpoints to group connected pins
+        into nets.
+        """
         print("Building netlist from schematic data")
-        
-        # TODO: Implement netlist building algorithm
-        # This is a complex task that involves:
-        # 1. Tracking connections between components via wires
-        # 2. Handling labels (local, global, hierarchical)
-        # 3. Processing power symbols
-        # 4. Resolving junctions
-        
-        # For now, we'll implement a basic version that creates a list of nets
-        # based on component references and pin numbers
-        
-        # Process global labels as nets
+
+        ROUND = 4
+
+        def pt(x: float, y: float) -> Tuple[float, float]:
+            return (round(float(x), ROUND), round(float(y), ROUND))
+
+        # --- Union-Find ---
+        uf: Dict[Tuple, Tuple] = {}
+
+        def find(p: Tuple) -> Tuple:
+            uf.setdefault(p, p)
+            root = p
+            while uf[root] != root:
+                root = uf[root]
+            node = p
+            while uf[node] != root:
+                uf[node], node = root, uf[node]
+            return root
+
+        def union(p1: Tuple, p2: Tuple) -> None:
+            r1, r2 = find(p1), find(p2)
+            if r1 != r2:
+                uf[r1] = r2
+
+        # Step 1: Wire connectivity
+        for wire in self.wires:
+            union(
+                pt(wire['start']['x'], wire['start']['y']),
+                pt(wire['end']['x'],   wire['end']['y']),
+            )
+
+        # Step 2: Register pin world positions (already rotation-corrected by skip)
+        placed_pin_world: Dict[Tuple[str, str], Tuple] = {}
+        for ref, comp in self.component_info.items():
+            if ref.startswith('#'):
+                continue
+            for pin_data in comp.get('pins', []):
+                world_pt = pt(pin_data['x'], pin_data['y'])
+                find(world_pt)  # register in uf
+                placed_pin_world[(ref, pin_data['num'])] = world_pt
+
+        # Step 3: Assign net names from labels
+        point_net: Dict[Tuple, str] = {}
+
+        def name_point(p: Tuple, name: str) -> None:
+            root = find(p)
+            if root not in point_net or name.upper() in ('GND', 'VCC', 'VDD', 'VSS', 'VEE'):
+                point_net[root] = name
+
+        for label in self.labels:
+            name_point(pt(label['position']['x'], label['position']['y']), label['text'])
+
         for label in self.global_labels:
-            net_name = label['text']
-            self.nets[net_name] = []  # Initialize empty list for this net
-        
-        # Process power symbols as nets
-        for power in self.power_symbols:
-            net_name = power['type']
+            name_point(pt(label['position']['x'], label['position']['y']), label['text'])
+
+        for label in self.hierarchical_labels:
+            name_point(pt(label['position']['x'], label['position']['y']), label['text'])
+
+        # Power symbol pins provide net names at their world positions.
+        # When skip cannot resolve pin.location for a power symbol (e.g. power:GND),
+        # fall back to the symbol's placement position, which in KiCad is always
+        # the connection point for single-pin power symbols.
+        for ref, comp in self.component_info.items():
+            if comp.get('lib_id', '').startswith('power:'):
+                power_name = comp['lib_id'].split(':', 1)[1]
+                pin_coords = comp.get('pins', [])
+                if pin_coords:
+                    for pin_data in pin_coords:
+                        name_point(pt(pin_data['x'], pin_data['y']), power_name)
+                else:
+                    pos = comp.get('position', {})
+                    if pos:
+                        name_point(pt(pos.get('x', 0), pos.get('y', 0)), power_name)
+
+        # Step 4: Group component pins by union-find group -> net
+        group_pins: Dict[Tuple, List] = defaultdict(list)
+        for (ref, pin_num), world_pt in placed_pin_world.items():
+            group_pins[find(world_pt)].append({'component': ref, 'pin': pin_num})
+
+        net_counter = [1]
+
+        def auto_net_name(root: Tuple, pins: List) -> str:
+            if root in point_net:
+                return point_net[root]
+            if len(pins) == 1:
+                return f"Net-({pins[0]['component']}-Pin{pins[0]['pin']})"
+            name = f"Net-{net_counter[0]}"
+            net_counter[0] += 1
+            return name
+
+        for root, pins in group_pins.items():
+            self.nets[auto_net_name(root, pins)].extend(pins)
+
+        # Register named nets that carry no component pins
+        for root, net_name in point_net.items():
             if net_name not in self.nets:
                 self.nets[net_name] = []
-        
-        # In a full implementation, we would now trace connections between
-        # components, but that requires a more complex algorithm to follow wires
-        # and detect connected pins
-        
-        # For demonstration, we'll add a placeholder note
-        print("Note: Full netlist building requires complex connectivity tracing")
-        print(f"Found {len(self.nets)} potential nets from labels and power symbols")
+
+        # Expose a flat point → net-name mapping so callers can look up a wire
+        # endpoint's net directly without re-running union-find.
+        for p in list(uf.keys()):
+            root = find(p)
+            if root in point_net:
+                self.point_to_net[p] = point_net[root]
+
+        print(f"Built netlist: {len(self.nets)} nets, "
+              f"{sum(len(v) for v in self.nets.values())} pin connections")
 
 
 def extract_netlist(schematic_path: str) -> Dict[str, Any]:
     """Extract netlist information from a KiCad schematic file.
-    
+
     Args:
         schematic_path: Path to the KiCad schematic file (.kicad_sch)
-        
+
     Returns:
         Dictionary with netlist information
     """

--- a/kicad_mcp/utils/skip_helpers.py
+++ b/kicad_mcp/utils/skip_helpers.py
@@ -1,0 +1,134 @@
+"""Helpers for working around known bugs in the skip library.
+
+The skip library fails to expose ``SymbolPin`` wrapper objects for
+single-pin symbols (power nets like VCC/GND/PWR_FLAG and test-point
+footprints).  When ``sym.pin`` is iterated on such symbols Python falls back
+via ``__getattr__`` to the raw ``ParsedValue``, yielding the pin's children
+(number string and UUID) instead of ``SymbolPin`` objects.  Every
+``pin.number`` / ``pin.location`` access then raises ``AttributeError``
+silently, leaving callers with no pin data.
+
+:func:`sym_pin_world_coords` provides a single canonical implementation that
+tries the normal ``SymbolPin`` path first and falls back to manual
+rotation/mirror math against the lib-symbol definition when the normal path
+yields nothing.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, NamedTuple
+
+
+class PinWorldCoords(NamedTuple):
+    """Absolute schematic position and exit direction of one pin."""
+
+    number: str    # pin number label, e.g. "1", "2", "A3"
+    x: float       # absolute schematic X (mm)
+    y: float       # absolute schematic Y (mm)
+    angle: float   # wire-exit direction in degrees:
+                   #   0=right, 90=down (screen), 180=left, 270=up (screen)
+
+
+def sym_pin_world_coords(sym: Any) -> list[PinWorldCoords]:
+    """Return world coordinates and exit angle for every pin of a placed symbol.
+
+    Handles the known skip library bug for single-pin symbols (power symbols
+    such as VCC, GND, PWR_FLAG and TestPoint footprints) by falling back to
+    manual rotation/mirror math when the normal ``SymbolPin`` wrapper path
+    yields no results.
+
+    Args:
+        sym: A placed symbol object from a ``skip.Schematic`` (the items
+            yielded by ``sch.symbol``).
+
+    Returns:
+        List of :class:`PinWorldCoords` named tuples, one per pin.  Empty on
+        any unrecoverable error.
+    """
+    from skip.at_location import AtValue  # local to avoid circular imports
+
+    results: list[PinWorldCoords] = []
+
+    # ---- Normal path via SymbolPin.location ---------------------------------
+    # Works for multi-pin components where skip correctly wraps each pin as a
+    # SymbolPin object with a .number attribute and a .location property that
+    # accounts for the symbol's placement rotation and mirroring.
+    try:
+        for pin in sym.pin:
+            try:
+                num = str(pin.number)
+                loc = pin.location
+                results.append(PinWorldCoords(
+                    number=num,
+                    x=round(float(loc.x), 4),
+                    y=round(float(loc.y), 4),
+                    angle=float(loc.rotation),
+                ))
+            except AttributeError:
+                continue
+    except (AttributeError, TypeError):
+        pass
+
+    if results:
+        return results
+
+    # ---- Fallback path: manual rotation/mirror math -------------------------
+    # Triggered for power symbols, PWR_FLAG, TestPoint, etc., where skip's
+    # SymbolPin wrapper is not produced by sym.pin iteration.  We read the
+    # lib-symbol pin definitions directly and replicate the same transform that
+    # skip's SymbolPin.location property applies internally.
+    try:
+        lib_sym = sym.lib_symbol
+        if lib_sym is None:
+            return results
+
+        sym_at = AtValue(sym.at.value)  # placed symbol: (x, y, rotation°)
+
+        # Determine mirroring (if any)
+        mirror_val: str | None = None
+        try:
+            mv = sym.mirror.value
+            mirror_val = mv.value() if hasattr(mv, "value") else mv
+        except AttributeError:
+            pass
+
+        for lib_pin in lib_sym.pin:
+            try:
+                num = str(lib_pin.number.value)
+                rel_raw: list = copy.deepcopy(lib_pin.at.value)  # [x, y, angle]
+
+                # Apply mirroring to lib-pin relative position
+                rot = rel_raw[2]
+                if mirror_val == "y":
+                    rel_raw[0] = -rel_raw[0]
+                    if rot % 180 == 0:
+                        rel_raw[2] = (rot + 180) % 360
+                elif mirror_val == "x":
+                    rel_raw[1] = -rel_raw[1]
+                    if rot % 90 == 0:
+                        rel_raw[2] = (rot + 180) % 360
+
+                rel_at = AtValue(rel_raw)
+                manip_at = AtValue(copy.deepcopy(rel_raw))
+                manip_at.rotation = 0
+
+                # Rotate lib-pin position/angle to match placed symbol's rotation
+                while manip_at.rotation != sym_at.rotation:
+                    manip_at.rotate90degrees()
+                    rel_at.rotate90degrees()
+
+                wx = round(sym_at.x + rel_at.x, 4)
+                wy = round(sym_at.y - rel_at.y, 4)  # lib Y axis is flipped
+                results.append(PinWorldCoords(
+                    number=num,
+                    x=wx,
+                    y=wy,
+                    angle=float(rel_at.rotation),
+                ))
+            except Exception:
+                continue
+    except Exception:
+        pass
+
+    return results


### PR DESCRIPTION
## Summary

- Rename `analyze_schematic_connections` → `extract_schematic_netlist`, replacing the old simpler version
- Add per-component pin→net mapping to components output
- Remove pins list from power_nets/signal_nets (pin info available via components)
- Replace `potential_issues` with `floating_nets` for cleaner output
- Use parser-resolved `point_to_net` for wire topology instead of union-find
- Change `include_wire_topology` default to `False`; wires now keyed by index
- Move `import re` to module top level
- Add `skip_helpers.py` with `sym_pin_world_coords()` to work around a known skip library bug for single-pin symbols (VCC/GND/PWR_FLAG)

## Files Changed

- `kicad_mcp/tools/netlist_tools.py` — merged and refactored
- `kicad_mcp/utils/netlist_parser.py` — improved parser
- `kicad_mcp/utils/skip_helpers.py` — new helper for single-pin symbol workaround