### PR TITLE
ci: add pip-audit dependency scan to security job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,10 @@ jobs:
     - name: Run security scan
       run: uv run bandit -r kicad_mcp/
 
+    - name: Scan dependencies with pip-audit
+      continue-on-error: true
+      run: uv run --with pip-audit pip-audit
+
   build:
     runs-on: ubuntu-latest
     name: Build Package


### PR DESCRIPTION
## Description

Adds a dependency vulnerability scan to the `security` job in
`.github/workflows/ci.yml`. Bandit covers source-code security; this
PR closes the gap by checking the locked dependency tree against the
PyPA Advisory Database with `pip-audit`.

```yaml
- name: Scan dependencies with pip-audit
  continue-on-error: true
  run: uv run --with pip-audit pip-audit
```

`pip-audit` (PyPA-maintained, no auth required) was chosen over
`safety` because the non-deprecated `safety scan` now requires an
account and API key.

`continue-on-error: true` keeps advisories informational — they
surface as annotations without blocking CI. The flag can be tightened
later once the baseline is clean.

## Related Issue(s)

None.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Testing Performed

- [x] Manually tested on macOS — `uv run --with pip-audit pip-audit`
  runs and reports findings against the current lockfile.
- [x] Workflow syntax validated by `actionlint`.

## Checklist

- [x] My code follows the project's coding style
- [x] My changes generate no new warnings or errors

## Additional Notes

Originally authored on a downstream fork; the branch was cut from
`lamaalrajih/kicad-mcp:main` and a single commit cherry-picked onto
it so it applies cleanly.