### PR TITLE
refactor: replace print() with logging in BOM/export/netlist modules

### DIFF
--- a/kicad_mcp/resources/bom_resources.py
+++ b/kicad_mcp/resources/bom_resources.py
@@ -4,6 +4,7 @@ Bill of Materials (BOM) resources for KiCad projects.
 import os
 import csv
 import json
+import logging
 import pandas as pd
 from typing import Dict, List, Any, Optional
 from mcp.server.fastmcp import FastMCP
@@ -12,6 +13,9 @@ from kicad_mcp.utils.file_utils import get_project_files
 
 # Import the helper functions from bom_tools.py to avoid code duplication
 from kicad_mcp.tools.bom_tools import parse_bom_file, analyze_bom_data
+
+logger = logging.getLogger(__name__)
+
 
 def register_bom_resources(mcp: FastMCP) -> None:
     """Register BOM-related resources with the MCP server.
@@ -30,7 +34,7 @@ def register_bom_resources(mcp: FastMCP) -> None:
         Returns:
             Markdown-formatted BOM report
         """
-        print(f"Generating BOM report for project: {project_path}")
+        logger.info("Generating BOM report for project: %s", project_path)
         
         if not os.path.exists(project_path):
             return f"Project not found: {project_path}"
@@ -43,10 +47,10 @@ def register_bom_resources(mcp: FastMCP) -> None:
         for file_type, file_path in files.items():
             if "bom" in file_type.lower() or file_path.lower().endswith(".csv"):
                 bom_files[file_type] = file_path
-                print(f"Found potential BOM file: {file_path}")
+                logger.debug("Found potential BOM file: %s", file_path)
         
         if not bom_files:
-            print("No BOM files found for project")
+            logger.info("No BOM files found for project")
             return f"# BOM Report\n\nNo BOM files found for project: {os.path.basename(project_path)}.\n\nExport a BOM from KiCad first, or use the `export_bom_csv` tool to generate one."
         
         # Format as Markdown report
@@ -151,7 +155,7 @@ def register_bom_resources(mcp: FastMCP) -> None:
                 report += "\n---\n\n"
             
             except Exception as e:
-                print(f"Error processing BOM file {file_path}: {str(e)}")
+                logger.error("Error processing BOM file %s: %s", file_path, e)
                 report += f"## {file_type}\n\nError processing BOM file: {str(e)}\n\n"
         
         # Add export instructions
@@ -175,7 +179,7 @@ def register_bom_resources(mcp: FastMCP) -> None:
         Returns:
             CSV-formatted BOM data
         """
-        print(f"Generating CSV BOM for project: {project_path}")
+        logger.info("Generating CSV BOM for project: %s", project_path)
 
         if not os.path.exists(project_path):
             return f"Project not found: {project_path}"
@@ -188,10 +192,10 @@ def register_bom_resources(mcp: FastMCP) -> None:
         for file_type, file_path in files.items():
             if "bom" in file_type.lower() or file_path.lower().endswith(".csv"):
                 bom_files[file_type] = file_path
-                print(f"Found potential BOM file: {file_path}")
+                logger.debug("Found potential BOM file: %s", file_path)
 
         if not bom_files:
-            print("No BOM files found for project")
+            logger.info("No BOM files found for project")
             return "No BOM files found for project. Export a BOM from KiCad first."
 
         # Use the first BOM file found
@@ -215,7 +219,7 @@ def register_bom_resources(mcp: FastMCP) -> None:
             return df.to_csv(index=False)
 
         except Exception as e:
-            print(f"Error generating CSV from BOM file: {str(e)}")
+            logger.error("Error generating CSV from BOM file: %s", e)
             return f"Error generating CSV from BOM file: {str(e)}"
 
     @mcp.resource("kicad://bom/{project_path}/json")
@@ -228,7 +232,7 @@ def register_bom_resources(mcp: FastMCP) -> None:
         Returns:
             JSON-formatted BOM data
         """
-        print(f"Generating JSON BOM for project: {project_path}")
+        logger.info("Generating JSON BOM for project: %s", project_path)
 
         if not os.path.exists(project_path):
             return f"Project not found: {project_path}"
@@ -241,10 +245,10 @@ def register_bom_resources(mcp: FastMCP) -> None:
         for file_type, file_path in files.items():
             if "bom" in file_type.lower() or file_path.lower().endswith((".csv", ".json")):
                 bom_files[file_type] = file_path
-                print(f"Found potential BOM file: {file_path}")
+                logger.debug("Found potential BOM file: %s", file_path)
 
         if not bom_files:
-            print("No BOM files found for project")
+            logger.info("No BOM files found for project")
             return json.dumps({"error": "No BOM files found for project"}, indent=2)
 
         try:
@@ -277,5 +281,5 @@ def register_bom_resources(mcp: FastMCP) -> None:
             return json.dumps(result, indent=2, default=str)
 
         except Exception as e:
-            print(f"Error generating JSON from BOM file: {str(e)}")
+            logger.error("Error generating JSON from BOM file: %s", e)
             return json.dumps({"error": str(e)}, indent=2)

--- a/kicad_mcp/tools/bom_tools.py
+++ b/kicad_mcp/tools/bom_tools.py
@@ -4,11 +4,15 @@ Bill of Materials (BOM) processing tools for KiCad projects.
 import os
 import csv
 import json
+import logging
 import pandas as pd
 from typing import Dict, List, Any, Optional, Tuple
 from mcp.server.fastmcp import FastMCP, Context, Image
 
 from kicad_mcp.utils.file_utils import get_project_files
+
+logger = logging.getLogger(__name__)
+
 
 def register_bom_tools(mcp: FastMCP) -> None:
     """Register BOM-related tools with the MCP server.
@@ -31,10 +35,10 @@ def register_bom_tools(mcp: FastMCP) -> None:
         Returns:
             Dictionary with BOM analysis results
         """
-        print(f"Analyzing BOM for project: {project_path}")
+        logger.info("Analyzing BOM for project: %s", project_path)
         
         if not os.path.exists(project_path):
-            print(f"Project not found: {project_path}")
+            logger.warning("Project not found: %s", project_path)
             if ctx:
                 ctx.info(f"Project not found: {project_path}")
             return {"success": False, "error": f"Project not found: {project_path}"}
@@ -52,10 +56,10 @@ def register_bom_tools(mcp: FastMCP) -> None:
         for file_type, file_path in files.items():
             if "bom" in file_type.lower() or file_path.lower().endswith(".csv"):
                 bom_files[file_type] = file_path
-                print(f"Found potential BOM file: {file_path}")
+                logger.debug("Found potential BOM file: %s", file_path)
         
         if not bom_files:
-            print("No BOM files found for project")
+            logger.info("No BOM files found for project")
             if ctx:
                 ctx.info("No BOM files found for project")
             return {
@@ -87,7 +91,7 @@ def register_bom_tools(mcp: FastMCP) -> None:
                 bom_data, format_info = parse_bom_file(file_path)
                 
                 if not bom_data or len(bom_data) == 0:
-                    print(f"Failed to parse BOM file: {file_path}")
+                    logger.warning("Failed to parse BOM file: %s", file_path)
                     continue
                 
                 # Analyze the BOM data
@@ -104,10 +108,10 @@ def register_bom_tools(mcp: FastMCP) -> None:
                 total_unique_components += analysis["unique_component_count"]
                 total_components += analysis["total_component_count"]
                 
-                print(f"Successfully analyzed BOM file: {file_path}")
+                logger.info("Successfully analyzed BOM file: %s", file_path)
                 
             except Exception as e:
-                print(f"Error analyzing BOM file {file_path}: {str(e)}", exc_info=True)
+                logger.error("Error analyzing BOM file %s: %s", file_path, e, exc_info=True)
                 results["bom_files"][file_type] = {
                     "path": file_path,
                     "error": str(e)
@@ -172,10 +176,10 @@ def register_bom_tools(mcp: FastMCP) -> None:
         Returns:
             Dictionary with export results
         """
-        print(f"Exporting BOM for project: {project_path}")
+        logger.info("Exporting BOM for project: %s", project_path)
         
         if not os.path.exists(project_path):
-            print(f"Project not found: {project_path}")
+            logger.warning("Project not found: %s", project_path)
             if ctx:
                 ctx.info(f"Project not found: {project_path}")
             return {"success": False, "error": f"Project not found: {project_path}"}
@@ -193,7 +197,7 @@ def register_bom_tools(mcp: FastMCP) -> None:
         
         # We need the schematic file to generate a BOM
         if "schematic" not in files:
-            print("Schematic file not found in project")
+            logger.warning("Schematic file not found in project")
             if ctx:
                 ctx.info("Schematic file not found in project")
             return {"success": False, "error": "Schematic file not found"}
@@ -217,7 +221,7 @@ def register_bom_tools(mcp: FastMCP) -> None:
                     ctx.info("Attempting to export BOM using KiCad Python modules...")
                 export_result = await export_bom_with_python(schematic_file, project_dir, project_name, ctx)
             except Exception as e:
-                print(f"Error exporting BOM with Python modules: {str(e)}", exc_info=True)
+                logger.error("Error exporting BOM with Python modules: %s", e, exc_info=True)
                 if ctx:
                     ctx.info(f"Error using Python modules: {str(e)}")
                 export_result = {"success": False, "error": str(e)}
@@ -229,7 +233,7 @@ def register_bom_tools(mcp: FastMCP) -> None:
                     ctx.info("Attempting to export BOM using command-line tools...")
                 export_result = await export_bom_with_cli(schematic_file, project_dir, project_name, ctx)
             except Exception as e:
-                print(f"Error exporting BOM with CLI: {str(e)}", exc_info=True)
+                logger.error("Error exporting BOM with CLI: %s", e, exc_info=True)
                 if ctx:
                     ctx.info(f"Error using command-line tools: {str(e)}")
                 export_result = {"success": False, "error": str(e)}
@@ -260,7 +264,7 @@ def parse_bom_file(file_path: str) -> Tuple[List[Dict[str, Any]], Dict[str, Any]
             - List of component dictionaries
             - Dictionary with format information
     """
-    print(f"Parsing BOM file: {file_path}")
+    logger.debug("Parsing BOM file: %s", file_path)
     
     # Check file extension
     _, ext = os.path.splitext(file_path)
@@ -360,18 +364,18 @@ def parse_bom_file(file_path: str) -> Tuple[List[Dict[str, Any]], Dict[str, Any]
                     for row in reader:
                         components.append(dict(row))
             except:
-                print(f"Failed to parse unknown file format: {file_path}")
+                logger.warning("Failed to parse unknown file format: %s", file_path)
                 return [], {"detected_format": "unsupported"}
     
     except Exception as e:
-        print(f"Error parsing BOM file: {str(e)}", exc_info=True)
+        logger.error("Error parsing BOM file: %s", e, exc_info=True)
         return [], {"error": str(e)}
     
     # Check if we actually got components
     if not components:
-        print(f"No components found in BOM file: {file_path}")
+        logger.warning("No components found in BOM file: %s", file_path)
     else:
-        print(f"Successfully parsed {len(components)} components from {file_path}")
+        logger.debug("Successfully parsed %d components from %s", len(components), file_path)
         
         # Add a sample of the fields found
         if components:
@@ -390,7 +394,7 @@ def analyze_bom_data(components: List[Dict[str, Any]], format_info: Dict[str, An
     Returns:
         Dictionary with analysis results
     """
-    print(f"Analyzing {len(components)} components")
+    logger.debug("Analyzing %d components", len(components))
     
     # Initialize results
     results = {
@@ -565,7 +569,7 @@ def analyze_bom_data(components: List[Dict[str, Any]], format_info: Dict[str, An
                     if "currency" not in results:
                         results["currency"] = "USD"  # Default
             except:
-                print("Failed to parse cost data")
+                logger.warning("Failed to parse cost data")
         
         # Add extra insights
         if ref_col and value_col:
@@ -575,7 +579,7 @@ def analyze_bom_data(components: List[Dict[str, Any]], format_info: Dict[str, An
             results["most_common_values"] = {str(k): int(v) for k, v in most_common.items()}
     
     except Exception as e:
-        print(f"Error analyzing BOM data: {str(e)}", exc_info=True)
+        logger.error("Error analyzing BOM data: %s", e, exc_info=True)
         # Fallback to basic analysis
         results["unique_component_count"] = len(components)
         results["total_component_count"] = len(components)
@@ -595,7 +599,7 @@ async def export_bom_with_python(schematic_file: str, output_dir: str, project_n
     Returns:
         Dictionary with export results
     """
-    print(f"Exporting BOM for schematic: {schematic_file}")
+    logger.info("Exporting BOM for schematic: %s", schematic_file)
     if ctx:
         await ctx.report_progress(30, 100)
     
@@ -607,7 +611,7 @@ async def export_bom_with_python(schematic_file: str, output_dir: str, project_n
         import kicad.pcbnew
         
         # For now, return a message indicating this method is not implemented yet
-        print("BOM export with Python modules not fully implemented")
+        logger.warning("BOM export with Python modules not fully implemented")
         if ctx:
             ctx.info("BOM export with Python modules not fully implemented yet")
         
@@ -618,7 +622,7 @@ async def export_bom_with_python(schematic_file: str, output_dir: str, project_n
         }
     
     except ImportError:
-        print("Failed to import KiCad Python modules")
+        logger.warning("Failed to import KiCad Python modules")
         return {
             "success": False,
             "error": "Failed to import KiCad Python modules",
@@ -642,7 +646,7 @@ async def export_bom_with_cli(schematic_file: str, output_dir: str, project_name
     import platform
     
     system = platform.system()
-    print(f"Exporting BOM using CLI tools on {system}")
+    logger.info("Exporting BOM using CLI tools on %s", system)
     if ctx:
         await ctx.report_progress(40, 100)
     
@@ -718,7 +722,7 @@ async def export_bom_with_cli(schematic_file: str, output_dir: str, project_name
         }
     
     try:
-        print(f"Running command: {' '.join(cmd)}")
+        logger.debug("Running command: %s", " ".join(cmd))
         if ctx:
             await ctx.report_progress(60, 100)
         
@@ -727,8 +731,8 @@ async def export_bom_with_cli(schematic_file: str, output_dir: str, project_name
         
         # Check if the command was successful
         if process.returncode != 0:
-            print(f"BOM export command failed with code {process.returncode}")
-            print(f"Error output: {process.stderr}")
+            logger.error("BOM export command failed with code %d", process.returncode)
+            logger.error("Error output: %s", process.stderr)
             
             return {
                 "success": False,
@@ -770,7 +774,7 @@ async def export_bom_with_cli(schematic_file: str, output_dir: str, project_name
         }
     
     except subprocess.TimeoutExpired:
-        print("BOM export command timed out after 30 seconds")
+        logger.error("BOM export command timed out after 30 seconds")
         return {
             "success": False,
             "error": "BOM export command timed out after 30 seconds",
@@ -778,7 +782,7 @@ async def export_bom_with_cli(schematic_file: str, output_dir: str, project_name
         }
     
     except Exception as e:
-        print(f"Error exporting BOM: {str(e)}", exc_info=True)
+        logger.error("Error exporting BOM: %s", e, exc_info=True)
         return {
             "success": False,
             "error": f"Error exporting BOM: {str(e)}",

--- a/kicad_mcp/tools/export_tools.py
+++ b/kicad_mcp/tools/export_tools.py
@@ -6,11 +6,15 @@ import tempfile
 import subprocess
 import shutil
 import asyncio
+import logging
 from typing import Dict, Any, Optional
 from mcp.server.fastmcp import FastMCP, Context, Image
 
 from kicad_mcp.utils.file_utils import get_project_files
 from kicad_mcp.config import KICAD_APP_PATH, system
+
+logger = logging.getLogger(__name__)
+
 
 def register_export_tools(mcp: FastMCP) -> None:
     """Register export tools with the MCP server.
@@ -37,10 +41,10 @@ def register_export_tools(mcp: FastMCP) -> None:
                 app_context = ctx.request_context.lifespan_context
             # Removed check for kicad_modules_available as we now use CLI
             
-            print(f"Generating thumbnail via CLI for project: {project_path}")
+            logger.info("Generating thumbnail via CLI for project: %s", project_path)
 
             if not os.path.exists(project_path):
-                print(f"Project not found: {project_path}")
+                logger.warning("Project not found: %s", project_path)
                 if ctx:
                     await ctx.info(f"Project not found: {project_path}")
                 return None
@@ -48,18 +52,18 @@ def register_export_tools(mcp: FastMCP) -> None:
             # Get PCB file from project
             files = get_project_files(project_path)
             if "pcb" not in files:
-                print("PCB file not found in project")
+                logger.warning("PCB file not found in project")
                 if ctx:
                     await ctx.info("PCB file not found in project")
                 return None
 
             pcb_file = files["pcb"]
-            print(f"Found PCB file: {pcb_file}")
+            logger.debug("Found PCB file: %s", pcb_file)
 
             # Check cache
             cache_key = f"thumbnail_cli_{pcb_file}_{os.path.getmtime(pcb_file)}"
             if app_context and hasattr(app_context, 'cache') and cache_key in app_context.cache:
-                print(f"Using cached CLI thumbnail for {pcb_file}")
+                logger.debug("Using cached CLI thumbnail for %s", pcb_file)
                 return app_context.cache[cache_key]
 
             if ctx:
@@ -73,24 +77,24 @@ def register_export_tools(mcp: FastMCP) -> None:
                     # Cache the result if possible
                     if app_context and hasattr(app_context, 'cache'):
                         app_context.cache[cache_key] = thumbnail
-                    print("Thumbnail generated successfully via CLI.")
+                    logger.info("Thumbnail generated successfully via CLI.")
                     return thumbnail
                 else:
-                     print("generate_thumbnail_with_cli returned None")
+                     logger.warning("generate_thumbnail_with_cli returned None")
                      if ctx:
                          await ctx.info("Failed to generate thumbnail using kicad-cli.")
                      return None
             except Exception as e:
-                print(f"Error calling generate_thumbnail_with_cli: {str(e)}", exc_info=True)
+                logger.error("Error calling generate_thumbnail_with_cli: %s", e, exc_info=True)
                 if ctx:
                     await ctx.info(f"Error generating thumbnail with kicad-cli: {str(e)}")
                 return None
             
         except asyncio.CancelledError:
-            print("Thumbnail generation cancelled")
+            logger.info("Thumbnail generation cancelled")
             raise  # Re-raise to let MCP know the task was cancelled
         except Exception as e:
-            print(f"Unexpected error in thumbnail generation: {str(e)}")
+            logger.error("Unexpected error in thumbnail generation: %s", e)
             if ctx:
                 await ctx.info(f"Error: {str(e)}")
             return None
@@ -99,7 +103,7 @@ def register_export_tools(mcp: FastMCP) -> None:
     async def generate_project_thumbnail(project_path: str, ctx: Context | None):
         """Generate a thumbnail of a KiCad project's PCB layout (Alias for generate_pcb_thumbnail)."""
         # This function now just calls the main CLI-based thumbnail generator
-        print(f"generate_project_thumbnail called, redirecting to generate_pcb_thumbnail for {project_path}")
+        logger.debug("generate_project_thumbnail called, redirecting to generate_pcb_thumbnail for %s", project_path)
         return await generate_pcb_thumbnail(project_path, ctx)
 
 # Helper functions for thumbnail generation
@@ -115,7 +119,7 @@ async def generate_thumbnail_with_cli(pcb_file: str, ctx: Context | None):
         Image object containing the PCB thumbnail or None if generation failed
     """
     try:
-        print("Attempting to generate thumbnail using KiCad CLI tools")
+        logger.info("Attempting to generate thumbnail using KiCad CLI tools")
         if ctx:
             await ctx.report_progress(20, 100)
 
@@ -134,7 +138,7 @@ async def generate_thumbnail_with_cli(pcb_file: str, ctx: Context | None):
             elif shutil.which("kicad-cli") is not None:
                 kicad_cli = "kicad-cli"  # Try to use from PATH
             else:
-                print(f"kicad-cli not found at {kicad_cli_path} or in PATH")
+                logger.warning("kicad-cli not found at %s or in PATH", kicad_cli_path)
                 return None
         elif system == "Windows":
             kicad_cli_path = os.path.join(KICAD_APP_PATH, "bin", "kicad-cli.exe")
@@ -145,15 +149,15 @@ async def generate_thumbnail_with_cli(pcb_file: str, ctx: Context | None):
             elif shutil.which("kicad-cli") is not None:
                 kicad_cli = "kicad-cli"  # Try to use from PATH (without .exe)
             else:
-                print(f"kicad-cli not found at {kicad_cli_path} or in PATH")
+                logger.warning("kicad-cli not found at %s or in PATH", kicad_cli_path)
                 return None
         elif system == "Linux":
             kicad_cli = shutil.which("kicad-cli")
             if not kicad_cli:
-                print("kicad-cli not found in PATH")
+                logger.warning("kicad-cli not found in PATH")
                 return None
         else:
-            print(f"Unsupported operating system: {system}")
+            logger.error("Unsupported operating system: %s", system)
             return None
 
         if ctx:
@@ -170,28 +174,28 @@ async def generate_thumbnail_with_cli(pcb_file: str, ctx: Context | None):
             pcb_file
         ]
 
-        print(f"Running command: {' '.join(cmd)}")
+        logger.debug("Running command: %s", " ".join(cmd))
         if ctx:
             await ctx.report_progress(50, 100)
 
         # Run the command
         try:
             process = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=30)
-            print(f"Command successful: {process.stdout}")
+            logger.debug("Command successful: %s", process.stdout)
 
             if ctx:
                 await ctx.report_progress(70, 100)
 
             # Check if the output file was created
             if not os.path.exists(output_file):
-                print(f"Output file not created: {output_file}")
+                logger.error("Output file not created: %s", output_file)
                 return None
 
             # Read the image file
             with open(output_file, 'rb') as f:
                 img_data = f.read()
 
-            print(f"Successfully generated thumbnail with CLI, size: {len(img_data)} bytes")
+            logger.info("Successfully generated thumbnail with CLI, size: %d bytes", len(img_data))
             if ctx:
                 await ctx.report_progress(90, 100)
                 # Inform user about the saved file
@@ -199,28 +203,28 @@ async def generate_thumbnail_with_cli(pcb_file: str, ctx: Context | None):
             return Image(data=img_data, format="svg") # <-- Changed format to svg
 
         except subprocess.CalledProcessError as e:
-            print(f"Command '{' '.join(e.cmd)}' failed with code {e.returncode}")
-            print(f"Stderr: {e.stderr}")
-            print(f"Stdout: {e.stdout}")
+            logger.error("Command '%s' failed with code %d", " ".join(e.cmd), e.returncode)
+            logger.error("Stderr: %s", e.stderr)
+            logger.error("Stdout: %s", e.stdout)
             if ctx:
                 await ctx.info(f"KiCad CLI command failed: {e.stderr or e.stdout}")
             return None
         except subprocess.TimeoutExpired:
-            print(f"Command timed out after 30 seconds: {' '.join(cmd)}")
+            logger.error("Command timed out after 30 seconds: %s", " ".join(cmd))
             if ctx:
                 await ctx.info("KiCad CLI command timed out")
             return None
         except Exception as e:
-            print(f"Error running CLI command: {str(e)}", exc_info=True)
+            logger.error("Error running CLI command: %s", e, exc_info=True)
             if ctx:
                 await ctx.info(f"Error running KiCad CLI: {str(e)}")
             return None
                 
     except asyncio.CancelledError:
-        print("CLI thumbnail generation cancelled")
+        logger.info("CLI thumbnail generation cancelled")
         raise
     except Exception as e:
-        print(f"Unexpected error in CLI thumbnail generation: {str(e)}")
+        logger.error("Unexpected error in CLI thumbnail generation: %s", e)
         if ctx:
             await ctx.info(f"Unexpected error: {str(e)}")
         return None

--- a/kicad_mcp/tools/netlist_tools.py
+++ b/kicad_mcp/tools/netlist_tools.py
@@ -1,12 +1,16 @@
 """
 Netlist extraction and analysis tools for KiCad schematics.
 """
+import logging
 import os
 from typing import Dict, Any
 from mcp.server.fastmcp import FastMCP, Context
 
 from kicad_mcp.utils.file_utils import get_project_files
 from kicad_mcp.utils.netlist_parser import extract_netlist, analyze_netlist
+
+logger = logging.getLogger(__name__)
+
 
 def register_netlist_tools(mcp: FastMCP) -> None:
     """Register netlist-related tools with the MCP server.
@@ -29,10 +33,10 @@ def register_netlist_tools(mcp: FastMCP) -> None:
         Returns:
             Dictionary with netlist information
         """
-        print(f"Extracting netlist from schematic: {schematic_path}")
+        logger.info("Extracting netlist from schematic: %s", schematic_path)
         
         if not os.path.exists(schematic_path):
-            print(f"Schematic file not found: {schematic_path}")
+            logger.warning("Schematic file not found: %s", schematic_path)
             if ctx:
                 ctx.info(f"Schematic file not found: {schematic_path}")
             return {"success": False, "error": f"Schematic file not found: {schematic_path}"}
@@ -51,7 +55,7 @@ def register_netlist_tools(mcp: FastMCP) -> None:
             netlist_data = extract_netlist(schematic_path)
             
             if "error" in netlist_data:
-                print(f"Error extracting netlist: {netlist_data['error']}")
+                logger.error("Error extracting netlist: %s", netlist_data["error"])
                 if ctx:
                     ctx.info(f"Error extracting netlist: {netlist_data['error']}")
                 return {"success": False, "error": netlist_data['error']}
@@ -89,7 +93,7 @@ def register_netlist_tools(mcp: FastMCP) -> None:
             return result
             
         except Exception as e:
-            print(f"Error extracting netlist: {str(e)}")
+            logger.error("Error extracting netlist: %s", e, exc_info=True)
             if ctx:
                 ctx.info(f"Error extracting netlist: {str(e)}")
             return {"success": False, "error": str(e)}
@@ -108,10 +112,10 @@ def register_netlist_tools(mcp: FastMCP) -> None:
         Returns:
             Dictionary with netlist information
         """
-        print(f"Extracting netlist for project: {project_path}")
+        logger.info("Extracting netlist for project: %s", project_path)
         
         if not os.path.exists(project_path):
-            print(f"Project not found: {project_path}")
+            logger.warning("Project not found: %s", project_path)
             if ctx:
                 ctx.info(f"Project not found: {project_path}")
             return {"success": False, "error": f"Project not found: {project_path}"}
@@ -125,13 +129,13 @@ def register_netlist_tools(mcp: FastMCP) -> None:
             files = get_project_files(project_path)
             
             if "schematic" not in files:
-                print("Schematic file not found in project")
+                logger.warning("Schematic file not found in project")
                 if ctx:
                     ctx.info("Schematic file not found in project")
                 return {"success": False, "error": "Schematic file not found in project"}
             
             schematic_path = files["schematic"]
-            print(f"Found schematic file: {schematic_path}")
+            logger.info("Found schematic file: %s", schematic_path)
             if ctx:
                 ctx.info(f"Found schematic file: {os.path.basename(schematic_path)}")
             
@@ -149,7 +153,7 @@ def register_netlist_tools(mcp: FastMCP) -> None:
             return result
             
         except Exception as e:
-            print(f"Error extracting project netlist: {str(e)}")
+            logger.error("Error extracting project netlist: %s", e, exc_info=True)
             if ctx:
                 ctx.info(f"Error extracting project netlist: {str(e)}")
             return {"success": False, "error": str(e)}
@@ -168,10 +172,10 @@ def register_netlist_tools(mcp: FastMCP) -> None:
         Returns:
             Dictionary with connection analysis
         """
-        print(f"Analyzing connections in schematic: {schematic_path}")
+        logger.info("Analyzing connections in schematic: %s", schematic_path)
         
         if not os.path.exists(schematic_path):
-            print(f"Schematic file not found: {schematic_path}")
+            logger.warning("Schematic file not found: %s", schematic_path)
             if ctx:
                 ctx.info(f"Schematic file not found: {schematic_path}")
             return {"success": False, "error": f"Schematic file not found: {schematic_path}"}
@@ -186,7 +190,7 @@ def register_netlist_tools(mcp: FastMCP) -> None:
             netlist_data = extract_netlist(schematic_path)
             
             if "error" in netlist_data:
-                print(f"Error extracting netlist: {netlist_data['error']}")
+                logger.error("Error extracting netlist: %s", netlist_data["error"])
                 if ctx:
                     ctx.info(f"Error extracting netlist: {netlist_data['error']}")
                 return {"success": False, "error": netlist_data['error']}
@@ -270,7 +274,7 @@ def register_netlist_tools(mcp: FastMCP) -> None:
             return result
             
         except Exception as e:
-            print(f"Error analyzing connections: {str(e)}")
+            logger.error("Error analyzing connections: %s", e, exc_info=True)
             if ctx:
                 ctx.info(f"Error analyzing connections: {str(e)}")
             return {"success": False, "error": str(e)}
@@ -290,10 +294,10 @@ def register_netlist_tools(mcp: FastMCP) -> None:
         Returns:
             Dictionary with component connection information
         """
-        print(f"Finding connections for component {component_ref} in project: {project_path}")
+        logger.info("Finding connections for component %s in project: %s", component_ref, project_path)
         
         if not os.path.exists(project_path):
-            print(f"Project not found: {project_path}")
+            logger.warning("Project not found: %s", project_path)
             if ctx:
                 ctx.info(f"Project not found: {project_path}")
             return {"success": False, "error": f"Project not found: {project_path}"}
@@ -307,13 +311,13 @@ def register_netlist_tools(mcp: FastMCP) -> None:
             files = get_project_files(project_path)
             
             if "schematic" not in files:
-                print("Schematic file not found in project")
+                logger.warning("Schematic file not found in project")
                 if ctx:
                     ctx.info("Schematic file not found in project")
                 return {"success": False, "error": "Schematic file not found in project"}
             
             schematic_path = files["schematic"]
-            print(f"Found schematic file: {schematic_path}")
+            logger.info("Found schematic file: %s", schematic_path)
             if ctx:
                 ctx.info(f"Found schematic file: {os.path.basename(schematic_path)}")
             
@@ -325,7 +329,7 @@ def register_netlist_tools(mcp: FastMCP) -> None:
             netlist_data = extract_netlist(schematic_path)
             
             if "error" in netlist_data:
-                print(f"Failed to extract netlist: {netlist_data['error']}")
+                logger.error("Failed to extract netlist: %s", netlist_data["error"])
                 if ctx:
                     ctx.info(f"Failed to extract netlist: {netlist_data['error']}")
                 return {"success": False, "error": netlist_data['error']}
@@ -333,7 +337,7 @@ def register_netlist_tools(mcp: FastMCP) -> None:
             # Check if component exists in the netlist
             components = netlist_data.get("components", {})
             if component_ref not in components:
-                print(f"Component {component_ref} not found in schematic")
+                logger.warning("Component %s not found in schematic", component_ref)
                 if ctx:
                     ctx.info(f"Component {component_ref} not found in schematic")
                 return {
@@ -436,7 +440,7 @@ def register_netlist_tools(mcp: FastMCP) -> None:
             return result
             
         except Exception as e:
-            print(f"Error finding component connections: {str(e)}", exc_info=True)
+            logger.error("Error finding component connections: %s", e, exc_info=True)
             if ctx:
                 ctx.info(f"Error finding component connections: {str(e)}")
             return {"success": False, "error": str(e)}

--- a/kicad_mcp/utils/netlist_parser.py
+++ b/kicad_mcp/utils/netlist_parser.py
@@ -1,10 +1,14 @@
 """
 KiCad schematic netlist extraction utilities.
 """
+import logging
 import os
 import re
 from typing import Any, Dict, List
 from collections import defaultdict
+
+logger = logging.getLogger(__name__)
+
 
 class SchematicParser:
     """Parser for KiCad schematic files to extract netlist information."""
@@ -39,15 +43,15 @@ class SchematicParser:
     def _load_schematic(self) -> None:
         """Load the schematic file content."""
         if not os.path.exists(self.schematic_path):
-            print(f"Schematic file not found: {self.schematic_path}")
+            logger.error("Schematic file not found: %s", self.schematic_path)
             raise FileNotFoundError(f"Schematic file not found: {self.schematic_path}")
         
         try:
             with open(self.schematic_path, 'r') as f:
                 self.content = f.read()
-                print(f"Successfully loaded schematic: {self.schematic_path}")
+                logger.debug("Successfully loaded schematic: %s", self.schematic_path)
         except Exception as e:
-            print(f"Error reading schematic file: {str(e)}")
+            logger.error("Error reading schematic file: %s", e, exc_info=True)
             raise
 
     def parse(self) -> Dict[str, Any]:
@@ -56,7 +60,7 @@ class SchematicParser:
         Returns:
             Dictionary with parsed netlist information
         """
-        print("Starting schematic parsing")
+        logger.info("Starting schematic parsing")
         
         # Extract symbols (components)
         self._extract_components()
@@ -91,7 +95,7 @@ class SchematicParser:
             "net_count": len(self.nets)
         }
         
-        print(f"Schematic parsing complete: found {len(self.component_info)} components and {len(self.nets)} nets")
+        logger.info("Schematic parsing complete: found %d components and %d nets", len(self.component_info), len(self.nets))
         return result
 
     def _extract_s_expressions(self, pattern: str) -> List[str]:
@@ -138,7 +142,7 @@ class SchematicParser:
 
     def _extract_components(self) -> None:
         """Extract component information from schematic."""
-        print("Extracting components")
+        logger.debug("Extracting components")
         
         # Extract all symbol expressions (components)
         symbols = self._extract_s_expressions(r'\(symbol\s+')
@@ -152,7 +156,7 @@ class SchematicParser:
                 ref = component.get('reference', 'Unknown')
                 self.component_info[ref] = component
         
-        print(f"Extracted {len(self.components)} components")
+        logger.debug("Extracted %d components", len(self.components))
 
     def _parse_component(self, symbol_expr: str) -> Dict[str, Any]:
         """Parse a component from a symbol S-expression.
@@ -215,7 +219,7 @@ class SchematicParser:
 
     def _extract_wires(self) -> None:
         """Extract wire information from schematic."""
-        print("Extracting wires")
+        logger.debug("Extracting wires")
         
         # Extract all wire expressions
         wires = self._extract_s_expressions(r'\(wire\s+')
@@ -235,11 +239,11 @@ class SchematicParser:
                     }
                 })
         
-        print(f"Extracted {len(self.wires)} wires")
+        logger.debug("Extracted %d wires", len(self.wires))
 
     def _extract_junctions(self) -> None:
         """Extract junction information from schematic."""
-        print("Extracting junctions")
+        logger.debug("Extracting junctions")
         
         # Extract all junction expressions
         junctions = self._extract_s_expressions(r'\(junction\s+')
@@ -253,11 +257,11 @@ class SchematicParser:
                     'y': float(xy_match.group(2))
                 })
         
-        print(f"Extracted {len(self.junctions)} junctions")
+        logger.debug("Extracted %d junctions", len(self.junctions))
 
     def _extract_labels(self) -> None:
         """Extract label information from schematic."""
-        print("Extracting labels")
+        logger.debug("Extracting labels")
         
         # Extract local labels
         local_labels = self._extract_s_expressions(r'\(label\s+')
@@ -312,11 +316,16 @@ class SchematicParser:
                     }
                 })
         
-        print(f"Extracted {len(self.labels)} local labels, {len(self.global_labels)} global labels, and {len(self.hierarchical_labels)} hierarchical labels")
+        logger.debug(
+            "Extracted %d local labels, %d global labels, and %d hierarchical labels",
+            len(self.labels),
+            len(self.global_labels),
+            len(self.hierarchical_labels),
+        )
 
     def _extract_power_symbols(self) -> None:
         """Extract power symbol information from schematic."""
-        print("Extracting power symbols")
+        logger.debug("Extracting power symbols")
         
         # Extract all power symbol expressions
         power_symbols = self._extract_s_expressions(r'\(symbol\s+\(lib_id\s+"power:')
@@ -336,11 +345,11 @@ class SchematicParser:
                     }
                 })
         
-        print(f"Extracted {len(self.power_symbols)} power symbols")
+        logger.debug("Extracted %d power symbols", len(self.power_symbols))
 
     def _extract_no_connects(self) -> None:
         """Extract no-connect information from schematic."""
-        print("Extracting no-connects")
+        logger.debug("Extracting no-connects")
         
         # Extract all no-connect expressions
         no_connects = self._extract_s_expressions(r'\(no_connect\s+')
@@ -354,11 +363,11 @@ class SchematicParser:
                     'y': float(xy_match.group(2))
                 })
         
-        print(f"Extracted {len(self.no_connects)} no-connects")
+        logger.debug("Extracted %d no-connects", len(self.no_connects))
 
     def _build_netlist(self) -> None:
         """Build the netlist from extracted components and connections."""
-        print("Building netlist from schematic data")
+        logger.debug("Building netlist from schematic data")
         
         # TODO: Implement netlist building algorithm
         # This is a complex task that involves:
@@ -386,8 +395,8 @@ class SchematicParser:
         # and detect connected pins
         
         # For demonstration, we'll add a placeholder note
-        print("Note: Full netlist building requires complex connectivity tracing")
-        print(f"Found {len(self.nets)} potential nets from labels and power symbols")
+        logger.debug("Note: Full netlist building requires complex connectivity tracing")
+        logger.debug("Found %d potential nets from labels and power symbols", len(self.nets))
 
 
 def extract_netlist(schematic_path: str) -> Dict[str, Any]:
@@ -403,7 +412,7 @@ def extract_netlist(schematic_path: str) -> Dict[str, Any]:
         parser = SchematicParser(schematic_path)
         return parser.parse()
     except Exception as e:
-        print(f"Error extracting netlist: {str(e)}")
+        logger.error("Error extracting netlist: %s", e, exc_info=True)
         return {
             "error": str(e),
             "components": {},


### PR DESCRIPTION
## Description

Migrate **109** `print()` calls across five modules to module-level
loggers. Mixing `print` and `logging` makes server output inconsistent:
MCP clients (and any consumer running the server as a subprocess)
cannot capture or filter `print()` output through the standard
`logging` pipeline.

| File | calls migrated |
|---|---|
| `kicad_mcp/resources/bom_resources.py` | 12 |
| `kicad_mcp/tools/bom_tools.py` | 29 |
| `kicad_mcp/tools/export_tools.py` | 27 |
| `kicad_mcp/tools/netlist_tools.py` | 20 |
| `kicad_mcp/utils/netlist_parser.py` | 21 |

Each module gets a top-level `logger = logging.getLogger(__name__)`.
Level chosen per call:

- `debug` — verbose internals (extracting components, parsing,
  cache hits, command dumps)
- `info` — progress milestones (starting an extraction, generating
  a BOM/thumbnail)
- `warning` — recoverable issues (file not found, missing optional
  data)
- `error` — handled exceptions, command failures

f-strings are replaced with lazy `%`-style formatting (`logger.info("…
%s", x)`) so log message strings are not built when the level is
filtered out — a common logging best practice.

## Related Issue(s)

None.

## Type of Change

- [x] Code refactoring (no functional changes)

## Testing Performed

- [x] Manually tested on macOS — `uv run pytest tests/ -q` → **39
  passed**, identical to the pristine `main` baseline.
- [x] AST-validated all 5 modified files.
- [x] `ruff check` issue count unchanged (401 pre-existing, none
  introduced).

## Additional Notes

Other modules (`drc_tools.py`, `drc_impl/cli_drc.py`,
`kicad_api_detection.py`, etc.) still have `print()` calls and can be
migrated in a follow-up PR if this approach is acceptable.

Originally authored on a downstream fork; the branch was cut from
`lamaalrajih/kicad-mcp:main` and the transformation re-derived against
upstream's current files (the fork's modules have diverged enough that
a direct cherry-pick wasn't viable).